### PR TITLE
Fix velocity tracking error calculation in stop test

### DIFF
--- a/decoupled_wbc/tests/control/main/teleop/test_g1_control_loop.py
+++ b/decoupled_wbc/tests/control/main/teleop/test_g1_control_loop.py
@@ -313,9 +313,9 @@ class LocomotionRunner:
             base_velocity_cmd = statistics["floating_base_vel"]["cmd"]
 
             base_velocity_tracking_err = []
-            for v_cmd, v in zip(base_velocity_cmd, base_velocity):  # TODO: check if this is correct
+            for v_cmd, v in zip(base_velocity_cmd, base_velocity):
                 if v_cmd.max() < 1e-4:
-                    base_velocity_tracking_err.append(v)
+                    base_velocity_tracking_err.append(np.linalg.norm(v - v_cmd))
             print(
                 f" [{GREEN_BOLD}INFO{RESET}] Base velocity tracking when stopped: "
                 f"{np.mean(base_velocity_tracking_err):.3f}"


### PR DESCRIPTION
Addresses issue #40. The base velocity tracking validation was computing error incorrectly by appending the raw velocity value instead of the scalar tracking difference between actual velocity and command velocity.

Changed to use np.linalg.norm(v - v_cmd) to match the pattern used in eef_pose_tracking_err calculation.