### PR TITLE
Feature/meta quest3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,152 @@
-<div align="center">
+# Meta Quest 3 — Teleoperación con Sonic
 
-  <img src="media/groot_wbc.png" width="800" alt="GEAR SONIC Header">
-
-  <!-- --- -->
-  
-  
-</div>
-
-<div align="center">
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-76B900.svg)](LICENSE)
-[![IsaacLab](https://img.shields.io/badge/IsaacLab-2.3.0-orange.svg)](https://github.com/isaac-sim/IsaacLab/releases/tag/v2.3.0)
-[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-76B900.svg)](https://nvlabs.github.io/GR00T-WholeBodyControl/)
-
-</div>
+Guía completa para usar **Meta Quest 3** como controlador de teleoperación con GEAR-SONIC (G1 robot).
 
 ---
 
+## Requisitos
 
+- **Meta Quest 3** con controladores
+- **PC** con Ubuntu (o Linux compatible)
+- **Python 3.10**
+- **ADB** (Android Debug Bridge)
+- **Conexión**: USB o WiFi (misma red que el Quest)
 
+---
 
-# GR00T-WholeBodyControl
+## 1. Instalar ADB
 
-This is the codebase for the **GR00T Whole-Body Control (WBC)** projects. It hosts model checkpoints and scripts for training, evaluating, and deploying advanced whole-body controllers for humanoid robots. We currently support:
-
-- **Decoupled WBC**: the decoupled controller (RL for lower body, and IK for upper body) used in NVIDIA GR00T [N1.5](https://research.nvidia.com/labs/gear/gr00t-n1_5/) and [N1.6](https://research.nvidia.com/labs/gear/gr00t-n1_6/) models;
-- **GEAR-SONIC Series**: our latest iteration of generalist humanoid whole-body controllers (see our [whitepaper](https://nvlabs.github.io/GEAR-SONIC/)).
-
-## Table of Contents
-
-- [GEAR-SONIC](#gear-sonic)
-- [VR Whole-Body Teleoperation](#vr-whole-body-teleoperation)
-- [Kinematic Planner](#kinematic-planner)
-- [TODOs](#todos)
-- [What's Included](#whats-included)
-  - [Setup](#setup)
-- [Documentation](#documentation)
-- [Citation](#citation)
-- [License](#license)
-- [Support](#support)
-- [Decoupled WBC](#decoupled-wbc)
-
-
-## GEAR-SONIC 
-
-<p style="font-size: 1.2em;">
-    <a href="https://nvlabs.github.io/GEAR-SONIC/"><strong>Website</strong></a> | 
-    <a href="https://huggingface.co/nvidia/GEAR-SONIC"><strong>Model</strong></a> | 
-    <a href="https://arxiv.org/abs/2511.07820"><strong>Paper</strong></a> | 
-    <a href="https://nvlabs.github.io/GR00T-WholeBodyControl/"><strong>Docs</strong></a>
-  </p>
-
-<div align="center">
-  <img src="docs/source/_static/sonic-preview-gif-480P.gif" width="800" >
-  
-</div>
-
-SONIC is a humanoid behavior foundation model that gives robots a core set of motor skills learned from large-scale human motion data. Rather than building separate controllers for predefined motions, SONIC uses motion tracking as a scalable training task, enabling a single unified policy to produce natural, whole-body movement and support a wide range of behaviors — from walking and crawling to teleoperation and multi-modal control. It is designed to generalize beyond the motions it has seen during training and to serve as a foundation for higher-level planning and interaction.
-
-In this repo, we will release SONIC's training code, deployment framework, model checkpoints, and teleoperation stack for data collection.
-
-
-## VR Whole-Body Teleoperation
-
-SONIC supports real-time whole-body teleoperation via PICO VR headset, enabling natural human-to-robot motion transfer for data collection and interactive control.
-
-### Meta Quest 3
-
-También puedes usar **Meta Quest 3** como controlador de teleoperación. Ver la guía completa:
-
-**[→ Meta Quest 3 — Guía de instalación y uso](TELEOPERATION_QUEST_SETUP.md)**
-
-Requisitos: ADB, `meta_quest_teleop`, Quest en modo desarrollador. El script `install_scripts/install_pico.sh` instala las dependencias necesarias.
-
-<div align="center">
-<table>
-<tr>
-<td align="center"><b>Walking</b></td>
-<td align="center"><b>Running</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_walking.gif" width="400"></td>
-<td align="center"><img src="media/teleop_running.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Sideways Movement</b></td>
-<td align="center"><b>Kneeling</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_sideways.gif" width="400"></td>
-<td align="center"><img src="media/teleop_kneeling.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Getting Up</b></td>
-<td align="center"><b>Jumping</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_getup.gif" width="400"></td>
-<td align="center"><img src="media/teleop_jumping.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Bimanual Manipulation</b></td>
-<td align="center"><b>Object Hand-off</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_bimanual.gif" width="400"></td>
-<td align="center"><img src="media/teleop_switch_hands.gif" width="400"></td>
-</tr>
-</table>
-</div>
-
-## Kinematic Planner
-
-SONIC includes a kinematic planner for real-time locomotion generation — choose a movement style, steer with keyboard/gamepad, and adjust speed and height on the fly.
-
-<div align="center">
-<table>
-<tr>
-<td align="center" colspan="2"><b>In-the-Wild Navigation</b></td>
-</tr>
-<tr>
-<td align="center" colspan="2"><img src="media/planner/planner_in_the_wild_navigation.gif" width="800"></td>
-</tr>
-<tr>
-<td align="center"><b>Run</b></td>
-<td align="center"><b>Happy</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_run.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_happy.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Stealth</b></td>
-<td align="center"><b>Injured</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_stealth.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_injured.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Kneeling</b></td>
-<td align="center"><b>Hand Crawling</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_kneeling.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_hand_crawling.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Elbow Crawling</b></td>
-<td align="center"><b>Boxing</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_elbow_crawling.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_boxing.gif" width="400"></td>
-</tr>
-</table>
-</div>
-
-## TODOs
-
-- [x] Release pretrained SONIC policy checkpoints
-- [x] Open source C++ inference stack
-- [x] Setup documentation
-- [x] Open source teleoperation stack and demonstration scripts
-- [ ] Release training scripts and recipes for motion imitation and fine-tuning
-- [ ] Open source large-scale data collection workflows and fine-tuning VLA scripts. 
-- [ ] Publish additional preprocessed large-scale human motion datasets
-
-
-
-## What's Included
-
-This release includes:
-
-- **`gear_sonic_deploy`**: C++ inference stack for deploying SONIC policies on real hardware
-- **`gear_sonic`**: Teleoperation stack for collecting demonstration data (no training code, YET.)
-
-### Setup
-
-Clone the repository with Git LFS:
 ```bash
-git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git
-cd GR00T-WholeBodyControl
+sudo apt update
+sudo apt install android-tools-adb android-tools-fastboot
+```
+
+Verificar:
+
+```bash
+adb version
+adb devices
+```
+
+### Permisos USB (si aparece "no permissions")
+
+```bash
+sudo bash -c 'cat > /etc/udev/rules.d/51-android.rules' << 'EOF'
+SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"
+EOF
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Desconecta y vuelve a conectar el Quest. Acepta el diálogo de depuración USB en el visor.
+
+---
+
+## 2. Configurar el Quest 3
+
+1. **Modo desarrollador**: Actívalo desde la app Meta Quest en el móvil (Ajustes → Modo desarrollador).
+2. **En el Quest**: Ajustes → Sistema → **Developer** → activa **USB Debugging**.
+3. **APK de teleop**: El paquete `meta_quest_teleop` instala automáticamente el APK al conectarte. Acepta la instalación cuando aparezca.
+
+---
+
+## 3. Clonar e instalar el proyecto
+
+```bash
+git clone https://github.com/josue99999/TELEOPERATION_SONIC.git
+cd TELEOPERATION_SONIC
 git lfs pull
 ```
 
-## Documentation
+### Entorno de teleoperación (incluye meta_quest_teleop)
 
-📚 **[Full Documentation](https://nvlabs.github.io/GR00T-WholeBodyControl/)**
+```bash
+bash install_scripts/install_pico.sh
+```
 
-### Getting Started
-- [Installation Guide](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/installation_deploy.html)
-- [Quick Start](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/quickstart.html)
-- [VR Teleoperation Setup](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/vr_teleop_setup.html)
+Esto crea `.venv_teleop` con `gear_sonic[teleop]`, que ya incluye `meta_quest_teleop`.
 
-### Tutorials
-- [Keyboard Control](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/keyboard.html)
-- [Gamepad Control](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/gamepad.html)
-- [ZMQ Communication](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/zmq.html)
-- [ZMQ Manager / PICO VR](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vr_wholebody_teleop.html)
+Activar:
 
-### Best Practices
-- [Teleoperation](https://nvlabs.github.io/GR00T-WholeBodyControl/user_guide/teleoperation.html)
-
-
-
-
-
-
----
-
-## Citation
-
-If you use GEAR-SONIC in your research, please cite:
-
-```bibtex
-@article{luo2025sonic,
-    title={SONIC: Supersizing Motion Tracking for Natural Humanoid Whole-Body Control},
-    author={Luo, Zhengyi and Yuan, Ye and Wang, Tingwu and Li, Chenran and Chen, Sirui and Casta\~neda, Fernando and Cao, Zi-Ang and Li, Jiefeng and Minor, David and Ben, Qingwei and Da, Xingye and Ding, Runyu and Hogg, Cyrus and Song, Lina and Lim, Edy and Jeong, Eugene and He, Tairan and Xue, Haoru and Xiao, Wenli and Wang, Zi and Yuen, Simon and Kautz, Jan and Chang, Yan and Iqbal, Umar and Fan, Linxi and Zhu, Yuke},
-    journal={arXiv preprint arXiv:2511.07820},
-    year={2025}
-}
+```bash
+source .venv_teleop/bin/activate
 ```
 
 ---
 
-## License
+## 4. Probar la conexión
 
-This project uses dual licensing:
+```bash
+# Con Quest conectado por USB
+python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb
+```
 
-- **Source Code**: Licensed under Apache License 2.0 - applies to all code, scripts, and software components in this repository
-- **Model Weights**: Licensed under NVIDIA Open Model License - applies to all trained model checkpoints and weights
-
-See [LICENSE](LICENSE) for the complete dual-license text.
-
-Please review both licenses before using this project. The NVIDIA Open Model License permits commercial use with attribution and requires compliance with NVIDIA's Trustworthy AI terms.
-
-All required legal documents, including the Apache 2.0 license, 3rd-party attributions, and DCO language, are consolidated in the /legal folder of this repository.
+Deberías ver `ADB connection OK` y el modelo del dispositivo.
 
 ---
 
-## Support
+## 5. Validar tracking (visualización 3D)
 
-For questions and issues, please contact the GEAR WBC team at [gear-wbc@nvidia.com](gear-wbc@nvidia.com) to provide feedback! 
+Antes de usar Sonic, comprueba que el tracking del Quest funciona:
 
-## Decoupled WBC
+```bash
+# USB
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw
 
-For the Decoupled WBC used in GR00T N1.5 and N1.6 models, please refer to the [Decoupled WBC documentation](docs/source/references/decoupled_wbc.md).
+# WiFi (sustituye por la IP de tu Quest)
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw --ip-address 192.168.x.x
+```
 
+Mueve los mandos y verifica que la visualización sigue. Ejes: **X=adelante (rojo)**, **Y=izquierda (verde)**, **Z=arriba (azul)**.
 
-## Acknowledgments
-We would like to acknowledge the following projects from which parts of the code in this repo are derived from:
-- [Beyond Mimic](https://github.com/HybridRobotics/whole_body_tracking)
-- [Isaac Lab](https://github.com/isaac-sim/IsaacLab)
+### Modo calibrado (G1 como referencia)
+
+```bash
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated
+```
+
+1. Pon el G1 en su **pose por defecto**.
+2. Adopta la **misma pose** con los controladores.
+3. Pulsa el **trigger derecho** para calibrar.
+4. A partir de ahí, la salida es: `pose_G1_default + delta_movimiento`.
+
+---
+
+## 6. Usar Quest con Sonic
+
+```bash
+python gear_sonic/scripts/pico_manager_thread_server.py \
+    --manager \
+    --reader quest
+```
+
+Por WiFi:
+
+```bash
+python gear_sonic/scripts/pico_manager_thread_server.py \
+    --manager \
+    --reader quest \
+    --quest-ip-address 192.168.x.x
+```
+
+**Calibración**: Igual que en `validate_quest_raw`: adopta la pose por defecto del G1 y pulsa **trigger derecho**.
+
+---
+
+## Resumen de comandos
+
+| Acción | Comando |
+|--------|---------|
+| Probar ADB | `python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb` |
+| Validar tracking (raw) | `python -m gear_sonic.utils.teleop.readers.validate_quest_raw` |
+| Validar tracking (calibrado) | `python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated` |
+| Sonic con Quest | `python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest` |
+
+---
+
+## Solución de problemas
+
+- **"No devices found"**: Revisa USB, modo desarrollador y depuración USB. Prueba `adb kill-server && adb start-server`.
+- **"meta_quest_teleop no instalado"**: Ejecuta `bash install_scripts/install_pico.sh` y activa `.venv_teleop`.
+- **Las manos van en dirección equivocada**: El reader corrige los ejes automáticamente. Si algo falla, usa `validate_quest_raw --calibrated` para comprobar.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,32 @@ Guía completa para usar **Meta Quest 3** como controlador de teleoperación con
 ## Requisitos
 
 - **Meta Quest 3** con controladores
-- **PC** con Ubuntu (o Linux compatible)
-- **Python 3.10**
+- **PC** con **Ubuntu 22.04** (probado aquí)
+- Acceso a Internet (para instalar dependencias)
 - **ADB** (Android Debug Bridge)
 - **Conexión**: USB o WiFi (misma red que el Quest)
+
+---
+
+## 0. Dependencias de sistema (Ubuntu 22.04)
+
+Instala las herramientas básicas que usa este repo y el script `install_pico.sh`:
+
+```bash
+sudo apt update
+sudo apt install -y \
+    git git-lfs \
+    build-essential \
+    curl \
+    python3 python3-venv python3-pip \
+    libgl1 libegl1 libx11-6
+```
+
+- `git` / `git-lfs`: para clonar este repo (usa ficheros grandes, vídeos, etc.).
+- `build-essential`: compilar librerías nativas (XRoboToolkit, etc.).
+- `curl`: necesario para que `install_pico.sh` pueda instalar `uv`.
+- `python3*`: utilidades básicas de Python (aunque `uv` instalará su propio Python 3.10 gestionado).
+- `libgl*` y `libx11-6`: librerías gráficas mínimas para PyVista/VTK (visualización 3D).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ In this repo, we will release SONIC's training code, deployment framework, model
 
 SONIC supports real-time whole-body teleoperation via PICO VR headset, enabling natural human-to-robot motion transfer for data collection and interactive control.
 
+### Meta Quest 3
+
+También puedes usar **Meta Quest 3** como controlador de teleoperación. Ver la guía completa:
+
+**[→ Meta Quest 3 — Guía de instalación y uso](TELEOPERATION_QUEST_SETUP.md)**
+
+Requisitos: ADB, `meta_quest_teleop`, Quest en modo desarrollador. El script `install_scripts/install_pico.sh` instala las dependencias necesarias.
+
 <div align="center">
 <table>
 <tr>

--- a/TELEOPERATION_QUEST_SETUP.md
+++ b/TELEOPERATION_QUEST_SETUP.md
@@ -156,6 +156,48 @@ python gear_sonic/scripts/pico_manager_thread_server.py \
 
 ---
 
+## 7. Ejecutar todo completo (sim + deploy + Quest)
+
+Abre **3 terminales** y ejecuta en este orden:
+
+### Terminal 1 — Simulación MuJoCo
+
+```bash
+cd TELEOPERATION_SONIC   # o la ruta donde clonaste el repo
+source .venv_sim/bin/activate   # o .venv_teleop si solo usaste install_pico.sh
+python gear_sonic/scripts/run_sim_loop.py
+```
+
+### Terminal 2 — Deploy (C++ inference)
+
+```bash
+cd TELEOPERATION_SONIC/gear_sonic_deploy
+source scripts/setup_env.sh
+./deploy.sh sim --input-type zmq_manager
+```
+
+Espera hasta ver **"Init done"**.
+
+### Terminal 3 — Manager con Quest
+
+```bash
+cd TELEOPERATION_SONIC
+source .venv_teleop/bin/activate
+
+# USB (recomendado la primera vez)
+python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest
+
+# Con visualización VR 3PT
+python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest --vis_vr3pt
+
+# WiFi (sustituye por la IP de tu Quest)
+python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest --quest-ip-address 192.168.x.x
+```
+
+**Orden**: 1 → 2 → 3. Calibra con el **trigger derecho** cuando el manager esté corriendo.
+
+---
+
 ## Resumen de comandos
 
 | Acción | Comando |

--- a/TELEOPERATION_QUEST_SETUP.md
+++ b/TELEOPERATION_QUEST_SETUP.md
@@ -7,10 +7,32 @@ Guía completa para usar **Meta Quest 3** como controlador de teleoperación con
 ## Requisitos
 
 - **Meta Quest 3** con controladores
-- **PC** con Ubuntu (o Linux compatible)
-- **Python 3.10**
+- **PC** con **Ubuntu 22.04** (probado aquí)
+- Acceso a Internet (para instalar dependencias)
 - **ADB** (Android Debug Bridge)
 - **Conexión**: USB o WiFi (misma red que el Quest)
+
+---
+
+## 0. Dependencias de sistema (Ubuntu 22.04)
+
+Instala las herramientas básicas que usa este repo y el script `install_pico.sh`:
+
+```bash
+sudo apt update
+sudo apt install -y \
+    git git-lfs \
+    build-essential \
+    curl \
+    python3 python3-venv python3-pip \
+    libgl1 libegl1 libx11-6
+```
+
+- `git` / `git-lfs`: para clonar este repo (usa ficheros grandes, vídeos, etc.).
+- `build-essential`: compilar librerías nativas (XRoboToolkit, etc.).
+- `curl`: necesario para que `install_pico.sh` pueda instalar `uv`.
+- `python3*`: utilidades básicas de Python (aunque `uv` instalará su propio Python 3.10 gestionado).
+- `libgl*` y `libx11-6`: librerías gráficas mínimas para PyVista/VTK (visualización 3D).
 
 ---
 

--- a/TELEOPERATION_QUEST_SETUP.md
+++ b/TELEOPERATION_QUEST_SETUP.md
@@ -1,0 +1,152 @@
+# Meta Quest 3 — Teleoperación con Sonic
+
+Guía completa para usar **Meta Quest 3** como controlador de teleoperación con GEAR-SONIC (G1 robot).
+
+---
+
+## Requisitos
+
+- **Meta Quest 3** con controladores
+- **PC** con Ubuntu (o Linux compatible)
+- **Python 3.10**
+- **ADB** (Android Debug Bridge)
+- **Conexión**: USB o WiFi (misma red que el Quest)
+
+---
+
+## 1. Instalar ADB
+
+```bash
+sudo apt update
+sudo apt install android-tools-adb android-tools-fastboot
+```
+
+Verificar:
+
+```bash
+adb version
+adb devices
+```
+
+### Permisos USB (si aparece "no permissions")
+
+```bash
+sudo bash -c 'cat > /etc/udev/rules.d/51-android.rules' << 'EOF'
+SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"
+EOF
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Desconecta y vuelve a conectar el Quest. Acepta el diálogo de depuración USB en el visor.
+
+---
+
+## 2. Configurar el Quest 3
+
+1. **Modo desarrollador**: Actívalo desde la app Meta Quest en el móvil (Ajustes → Modo desarrollador).
+2. **En el Quest**: Ajustes → Sistema → **Developer** → activa **USB Debugging**.
+3. **APK de teleop**: El paquete `meta_quest_teleop` instala automáticamente el APK al conectarte. Acepta la instalación cuando aparezca.
+
+---
+
+## 3. Clonar e instalar el proyecto
+
+```bash
+git clone https://github.com/josue99999/TELEOPERATION_SONIC.git
+cd TELEOPERATION_SONIC
+git lfs pull
+```
+
+### Entorno de teleoperación (incluye meta_quest_teleop)
+
+```bash
+bash install_scripts/install_pico.sh
+```
+
+Esto crea `.venv_teleop` con `gear_sonic[teleop]`, que ya incluye `meta_quest_teleop`.
+
+Activar:
+
+```bash
+source .venv_teleop/bin/activate
+```
+
+---
+
+## 4. Probar la conexión
+
+```bash
+# Con Quest conectado por USB
+python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb
+```
+
+Deberías ver `ADB connection OK` y el modelo del dispositivo.
+
+---
+
+## 5. Validar tracking (visualización 3D)
+
+Antes de usar Sonic, comprueba que el tracking del Quest funciona:
+
+```bash
+# USB
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw
+
+# WiFi (sustituye por la IP de tu Quest)
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw --ip-address 192.168.x.x
+```
+
+Mueve los mandos y verifica que la visualización sigue. Ejes: **X=adelante (rojo)**, **Y=izquierda (verde)**, **Z=arriba (azul)**.
+
+### Modo calibrado (G1 como referencia)
+
+```bash
+python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated
+```
+
+1. Pon el G1 en su **pose por defecto**.
+2. Adopta la **misma pose** con los controladores.
+3. Pulsa el **trigger derecho** para calibrar.
+4. A partir de ahí, la salida es: `pose_G1_default + delta_movimiento`.
+
+---
+
+## 6. Usar Quest con Sonic
+
+```bash
+python gear_sonic/scripts/pico_manager_thread_server.py \
+    --manager \
+    --reader quest
+```
+
+Por WiFi:
+
+```bash
+python gear_sonic/scripts/pico_manager_thread_server.py \
+    --manager \
+    --reader quest \
+    --quest-ip-address 192.168.x.x
+```
+
+**Calibración**: Igual que en `validate_quest_raw`: adopta la pose por defecto del G1 y pulsa **trigger derecho**.
+
+---
+
+## Resumen de comandos
+
+| Acción | Comando |
+|--------|---------|
+| Probar ADB | `python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb` |
+| Validar tracking (raw) | `python -m gear_sonic.utils.teleop.readers.validate_quest_raw` |
+| Validar tracking (calibrado) | `python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated` |
+| Sonic con Quest | `python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest` |
+
+---
+
+## Solución de problemas
+
+- **"No devices found"**: Revisa USB, modo desarrollador y depuración USB. Prueba `adb kill-server && adb start-server`.
+- **"meta_quest_teleop no instalado"**: Ejecuta `bash install_scripts/install_pico.sh` y activa `.venv_teleop`.
+- **Las manos van en dirección equivocada**: El reader corrige los ejes automáticamente. Si algo falla, usa `validate_quest_raw --calibrated` para comprobar.

--- a/gear_sonic/pyproject.toml
+++ b/gear_sonic/pyproject.toml
@@ -33,6 +33,7 @@ teleop = [
     "msgpack",
     "pin",
     "pyvista; platform_machine != 'aarch64'",
+    "meta_quest_teleop @ git+https://github.com/BrikHMP18/meta_quest_teleop.git@07bc15437f767c3517138367b6b3e3910b388c76",
 ]
 # MuJoCo simulation (run_sim_loop.py and related scripts)
 # Usage: pip install -e "gear_sonic[sim]"

--- a/gear_sonic/scripts/pico_manager_thread_server.py
+++ b/gear_sonic/scripts/pico_manager_thread_server.py
@@ -96,6 +96,11 @@ except ImportError:
     print("Warning: get_g1_key_frame_poses not available (pyvista may not be installed).")
     get_g1_key_frame_poses = None
 
+try:
+    from gear_sonic.utils.teleop.readers.quest_reader import QuestReader
+except ImportError:
+    QuestReader = None
+
 
 class LocomotionMode(IntEnum):
     """Locomotion mode enum for robot movement."""
@@ -692,6 +697,51 @@ def get_abxy_buttons():
         return False, False, False, False
 
 
+def get_controller_from_quest_sample(sample):
+    """
+    Extract controller state from QuestReader sample (when source=meta_quest).
+
+    Returns:
+        abxy: (a, b, x, y) booleans
+        axes: (lx, ly, rx, ry) floats
+        inputs: (left_menu, left_trigger, right_trigger, left_grip, right_grip)
+        axis_clicks: (left_axis_click, right_axis_click) booleans
+    """
+    if sample is None:
+        return (
+            (False, False, False, False),
+            (0.0, 0.0, 0.0, 0.0),
+            (False, 0.0, 0.0, 0.0, 0.0),
+            (False, False),
+        )
+    abxy = (
+        bool(sample.get("button_a", False)),
+        bool(sample.get("button_b", False)),
+        bool(sample.get("button_x", False)),
+        bool(sample.get("button_y", False)),
+    )
+    la = sample.get("left_axis", (0.0, 0.0))
+    ra = sample.get("right_axis", (0.0, 0.0))
+    axes = (
+        float(la[0]) if len(la) >= 1 else 0.0,
+        float(la[1]) if len(la) >= 2 else 0.0,
+        float(ra[0]) if len(ra) >= 1 else 0.0,
+        float(ra[1]) if len(ra) >= 2 else 0.0,
+    )
+    inputs = (
+        bool(sample.get("left_menu_button", False)),
+        float(sample.get("left_trigger", 0.0)),
+        float(sample.get("right_trigger", 0.0)),
+        float(sample.get("left_grip", 0.0)),
+        float(sample.get("right_grip", 0.0)),
+    )
+    axis_clicks = (
+        bool(sample.get("left_axis_click", False)),
+        bool(sample.get("right_axis_click", False)),
+    )
+    return abxy, axes, inputs, axis_clicks
+
+
 def compute_hand_joints_from_inputs(
     left_solver, right_solver, left_trigger, left_grip, right_trigger, right_grip
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -1006,11 +1056,21 @@ class ThreePointPose:
             except Exception as e:
                 print(f"[{self.log_prefix}] Warning: Error closing VR3pt visualizer: {e}")
 
-    def calibrate_now(self, body_poses_np: np.ndarray) -> bool:
-        """Calibrate using current SMPL frame against FK of all-zero body joints.
-        Operator should be in zero-reference pose when calling this."""
+    def calibrate_now(
+        self,
+        body_poses_np: np.ndarray | None = None,
+        vr_3pt_pose: np.ndarray | None = None,
+    ) -> bool:
+        """Calibrate using current SMPL frame or vr_3pt_pose against FK of all-zero body joints.
+        Operator should be in zero-reference pose when calling this.
+        Pass either body_poses_np (Pico SMPL) or vr_3pt_pose (Quest controllers)."""
         try:
-            vr_3pt_pose_raw = _process_3pt_pose(body_poses_np)
+            if vr_3pt_pose is not None:
+                vr_3pt_pose_raw = vr_3pt_pose
+            elif body_poses_np is not None:
+                vr_3pt_pose_raw = _process_3pt_pose(body_poses_np)
+            else:
+                return False
             self._override_robot_q = np.zeros(29, dtype=np.float64)
             self._capture_calibration(vr_3pt_pose_raw)
             print(f"[{self.log_prefix}] Calibration completed (zero-pose reference)")
@@ -1620,15 +1680,17 @@ class PlannerStreamer:
     def __init__(
         self,
         socket,
-        reader: PicoReader,
+        reader,
         three_point: ThreePointPose,
         poll_hz: int = 20,
         zmq_feedback_host: str = "localhost",
         zmq_feedback_port: int = 5557,
+        use_quest_controller: bool = False,
     ):
         self.socket = socket
         self.reader = reader
         self.three_point = three_point
+        self.use_quest_controller = use_quest_controller
         self.feedback_reader = FeedbackReader(
             zmq_feedback_host=zmq_feedback_host, zmq_feedback_port=zmq_feedback_port
         )
@@ -1677,14 +1739,46 @@ class PlannerStreamer:
     def run_once(self, stream_mode: StreamMode):
         """Execute one iteration of the planner control loop."""
         try:
-            # Avoid sending old commands if XRT timestamp hasn't advanced, in case of headset disconnect
-            xrt_timestamp = xrt.get_time_stamp_ns()
-            if xrt_timestamp == self.last_xrt_timestamp:
-                return
-            self.last_xrt_timestamp = xrt_timestamp
+            if self.use_quest_controller:
+                sample = self.reader.get_latest()
+                if sample is None:
+                    return
+                # Use sample timestamp instead of xrt (no PICO)
+                ts = sample.get("timestamp_ns", 0)
+                if ts == self.last_xrt_timestamp:
+                    return
+                self.last_xrt_timestamp = ts
+                abxy, axes, inputs, axis_clicks = get_controller_from_quest_sample(sample)
+                a_pressed, b_pressed, x_pressed, y_pressed = abxy
+                lx, ly, rx, ry = axes
+                (
+                    left_menu_button,
+                    left_trigger,
+                    right_trigger,
+                    left_grip,
+                    right_grip,
+                ) = inputs
+                left_axis_click, right_axis_click = axis_clicks
+            else:
+                # Avoid sending old commands if XRT timestamp hasn't advanced
+                if xrt is None:
+                    return
+                xrt_timestamp = xrt.get_time_stamp_ns()
+                if xrt_timestamp == self.last_xrt_timestamp:
+                    return
+                self.last_xrt_timestamp = xrt_timestamp
 
-            # A+B => next mode; X+Y => previous mode (rising edges)
-            a_pressed, b_pressed, x_pressed, y_pressed = get_abxy_buttons()
+                # A+B => next mode; X+Y => previous mode (rising edges)
+                a_pressed, b_pressed, x_pressed, y_pressed = get_abxy_buttons()
+                lx, ly, rx, ry = get_controller_axes()
+                (
+                    left_menu_button,
+                    left_trigger,
+                    right_trigger,
+                    left_grip,
+                    right_grip,
+                ) = get_controller_inputs()
+                left_axis_click, right_axis_click = get_axis_clicks()
             ab_now = bool(a_pressed) and bool(b_pressed)
             xy_now = bool(x_pressed) and bool(y_pressed)
             if ab_now and not self.prev_ab:
@@ -1695,9 +1789,6 @@ class PlannerStreamer:
                 print(f"[PlannerLoop] Mode -> {self.mode.value}: {self.mode.name}")
             self.prev_ab = ab_now
             self.prev_xy = xy_now
-
-            # Read axes/joysticks to control movement, facing, speed and mode
-            lx, ly, rx, ry = get_controller_axes()
 
             # Facing from RIGHT stick: continuous yaw based on rx (right = turn right, left = turn left)
             facing = self.yaw_accumulator.update(rx, self.dt)
@@ -1746,20 +1837,25 @@ class PlannerStreamer:
             if stream_mode == StreamMode.PLANNER_VR_3PT:
                 sample = self.reader.get_latest()
                 if sample is not None:
-                    print("[PlannerLoop] Sending VR 3-point pose as target")
-                    vr_3pt_pose = self.three_point.process_smpl_pose(sample["body_poses_np"])
+                    # Use vr_3pt_pose directly when present (e.g. from QuestReader with meta_quest)
+                    if "vr_3pt_pose" in sample:
+                        vr_3pt_pose = sample["vr_3pt_pose"]
+                    else:
+                        vr_3pt_pose = self.three_point.process_smpl_pose(sample["body_poses_np"])
                     vr_3pt_position = (vr_3pt_pose[:, :3].flatten()).tolist()
                     vr_3pt_orientation = vr_3pt_pose[:, 3:].flatten().tolist()
 
                 # Compute hand joints from trigger/grip inputs so operator can
                 # control hand open/close while in VR 3PT mode
-                (
-                    left_menu_button,
-                    left_trigger,
-                    right_trigger,
-                    left_grip,
-                    right_grip,
-                ) = get_controller_inputs()
+                # (left_trigger etc. already set from sample when use_quest_controller)
+                if not self.use_quest_controller:
+                    (
+                        left_menu_button,
+                        left_trigger,
+                        right_trigger,
+                        left_grip,
+                        right_grip,
+                    ) = get_controller_inputs()
                 lh_joints, rh_joints = compute_hand_joints_from_inputs(
                     self.left_hand_ik_solver,
                     self.right_hand_ik_solver,
@@ -1814,23 +1910,35 @@ def run_pico_manager(
     with_g1_robot: bool = True,
     enable_waist_tracking: bool = False,
     enable_smpl_vis: bool = False,
+    reader_type: str = "pico",
+    quest_ip_address: str | None = None,
 ):
     """
     Manager: creates shared PUB socket and runs pose/planner streamers based on current mode.
     Controller input:
       A+X: Toggle between planner and pose mode
       A+B+X+Y: Toggle policy start/stop
+
+    reader_type: "pico" (default) or "quest" for Meta Quest via meta_quest_teleop
     """
-    if xrt is None:
-        raise ImportError(
-            "XRoboToolkit SDK not available. Install xrobotoolkit_sdk to run the manager."
-        )
-    subprocess.Popen(["bash", "/opt/apps/roboticsservice/runService.sh"])
-    xrt.init()
-    print("Waiting for body tracking data...")
-    while not xrt.is_body_data_available():
-        print("waiting for body data...")
-        time.sleep(1)
+    use_quest = reader_type.lower() == "quest"
+    if use_quest:
+        if QuestReader is None:
+            raise ImportError(
+                "QuestReader not available. Install gear_sonic with meta_quest_teleop."
+            )
+        print("[Manager] Using QuestReader (Meta Quest). Connect Quest and press right trigger to calibrate.")
+    else:
+        if xrt is None:
+            raise ImportError(
+                "XRoboToolkit SDK not available. Install xrobotoolkit_sdk to run the manager."
+            )
+        subprocess.Popen(["bash", "/opt/apps/roboticsservice/runService.sh"])
+        xrt.init()
+        print("Waiting for body tracking data...")
+        while not xrt.is_body_data_available():
+            print("waiting for body data...")
+            time.sleep(1)
 
     context = zmq.Context()
     socket = context.socket(zmq.PUB)
@@ -1847,9 +1955,7 @@ def run_pico_manager(
         pass
 
     # Create shared reader and 3-point pose processor
-    reader = PicoReader(max_queue_size=buffer_size)
-    reader.start()
-
+    # For Quest: create three_point first to get G1 FK default poses for calibration reference
     three_point = ThreePointPose(
         enable_vis_vr3pt=enable_vis_vr3pt,
         with_g1_robot=with_g1_robot,
@@ -1857,6 +1963,32 @@ def run_pico_manager(
         enable_smpl_vis=enable_smpl_vis,
         log_prefix="PoseLoop",
     )
+
+    if use_quest:
+        home_left_4x4 = None
+        home_right_4x4 = None
+        if get_g1_key_frame_poses is not None:
+            from gear_sonic.utils.teleop.readers.quest_reader import _g1_pose_to_4x4
+
+            g1_poses = get_g1_key_frame_poses(three_point._robot_model)
+            home_left_4x4 = _g1_pose_to_4x4(
+                g1_poses["left_wrist"]["position"],
+                g1_poses["left_wrist"]["orientation_wxyz"],
+            )
+            home_right_4x4 = _g1_pose_to_4x4(
+                g1_poses["right_wrist"]["position"],
+                g1_poses["right_wrist"]["orientation_wxyz"],
+            )
+            print("[Manager] Quest calibration will use G1 FK default pose as reference.")
+        reader = QuestReader(
+            source="meta_quest",
+            ip_address=quest_ip_address,
+            home_left_pose=home_left_4x4,
+            home_right_pose=home_right_4x4,
+        )
+    else:
+        reader = PicoReader(max_queue_size=buffer_size)
+    reader.start()
 
     pose_streamer = PoseStreamer(
         socket=socket,
@@ -1876,6 +2008,7 @@ def run_pico_manager(
         poll_hz=20,
         zmq_feedback_host=zmq_feedback_host,
         zmq_feedback_port=zmq_feedback_port,
+        use_quest_controller=use_quest,
     )
 
     # State machine diagram:
@@ -1904,12 +2037,20 @@ def run_pico_manager(
         prev_start_combo = False
         prev_left_axis_click = False
         while True:
-            # Poll Pico controller for buttons/axes
-            a_pressed, b_pressed, x_pressed, y_pressed = get_abxy_buttons()
-
-            left_menu_button, _, _, _, _ = get_controller_inputs()
-
-            left_axis_click, _ = get_axis_clicks()
+            # Poll controller for buttons/axes (Pico via xrt, or Quest from sample)
+            if use_quest:
+                sample = reader.get_latest()
+                if sample is None:
+                    time.sleep(0.02)
+                    continue
+                abxy, _, inputs, axis_clicks = get_controller_from_quest_sample(sample)
+                a_pressed, b_pressed, x_pressed, y_pressed = abxy
+                left_menu_button = inputs[0]
+                left_axis_click = axis_clicks[0]
+            else:
+                a_pressed, b_pressed, x_pressed, y_pressed = get_abxy_buttons()
+                left_menu_button, _, _, _, _ = get_controller_inputs()
+                left_axis_click, _ = get_axis_clicks()
 
             # Rising edge: A+X pressed together -> toggle POSE/PLANNER mode
             ax_pressed = (a_pressed) and (x_pressed)
@@ -1925,12 +2066,14 @@ def run_pico_manager(
                 if start_combo and not prev_start_combo:
                     new_mode = StreamMode.PLANNER
                     # Calibrate VR 3pt tracking NOW: operator should be in zero-ref pose.
-                    # Uses the current Pico SMPL frame + FK of all-zero body joints.
                     sample = reader.get_latest()
                     if sample is not None:
-                        three_point.calibrate_now(sample["body_poses_np"])
+                        if use_quest and "vr_3pt_pose" in sample:
+                            three_point.calibrate_now(vr_3pt_pose=sample["vr_3pt_pose"])
+                        else:
+                            three_point.calibrate_now(body_poses_np=sample["body_poses_np"])
                     else:
-                        print("[Manager] WARNING: No SMPL data available for calibration")
+                        print("[Manager] WARNING: No pose data available for calibration")
 
             elif current_mode == StreamMode.PLANNER:
                 # Chain 2: POSE <--(ax)--> PLANNER <--(left_axis_click)--> VR_3PT
@@ -2136,6 +2279,19 @@ if __name__ == "__main__":
         action="store_true",
         help="Enable SMPL body joint visualization (24 joint spheres) in the VR3pt viewer",
     )
+    parser.add_argument(
+        "--reader",
+        type=str,
+        default="pico",
+        choices=["pico", "quest"],
+        help="Input reader: 'pico' (default) or 'quest' for Meta Quest via meta_quest_teleop",
+    )
+    parser.add_argument(
+        "--quest-ip-address",
+        type=str,
+        default=None,
+        help="Meta Quest IP address (for --reader quest). If not set, uses USB or default WiFi.",
+    )
     args = parser.parse_args()
 
     # Standalone VR3Pt test modes (exit after finishing)
@@ -2176,6 +2332,8 @@ if __name__ == "__main__":
             with_g1_robot=with_g1_robot,
             enable_waist_tracking=args.waist_tracking,
             enable_smpl_vis=args.vis_smpl,
+            reader_type=args.reader,
+            quest_ip_address=args.quest_ip_address or None,
         )
     else:
         # Run legacy single-thread pose streaming

--- a/gear_sonic/scripts/pico_manager_thread_server.py
+++ b/gear_sonic/scripts/pico_manager_thread_server.py
@@ -590,16 +590,6 @@ def compute_from_body_poses(parent_indices: list, device, body_poses_np: np.ndar
     return process_smpl_joints(body_pose, global_orient, transl)
 
 
-# def compute_latest_frame(parent_indices: list, device) -> tuple[np.ndarray, np.ndarray]:
-#     """
-#     Pull body data from XRoboToolkit, compute local SMPL joints and body orientation.
-#     Returns (smpl_joints_local_np [24,3], global_orient_quat_np [4,])
-#     """
-#     body_poses = xrt.get_body_joints_pose()
-#     body_poses_np = np.array(body_poses)
-#     return compute_from_body_poses(parent_indices, device, body_poses_np)
-
-
 def init_hand_ik_solvers():
     """Initialize hand IK solvers if available."""
     if G1GripperInverseKinematicsSolver is not None:
@@ -1245,7 +1235,6 @@ class PoseStreamer:
         self.log_prefix = log_prefix
 
         # Injected dependencies
-        self.reader = reader
         self.three_point = three_point
 
         self.device = (

--- a/gear_sonic/utils/teleop/readers/README.md
+++ b/gear_sonic/utils/teleop/readers/README.md
@@ -1,0 +1,123 @@
+# Quest 3 reader
+
+Reader de body pose para Quest 3, compatible con el formato de `PicoReader` para teleop.
+
+## Probar la conexión ADB (Quest 3 por USB)
+
+Con el Quest 3 conectado y depuración USB activada:
+
+```bash
+# Desde la raíz del repo, usar el venv del proyecto
+.venv_sim/bin/python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb
+```
+
+Si hay dispositivo: verás "ADB connection OK" y el modelo. Si no: "No devices found".
+
+## Probar el reader con datos sintéticos (sin Quest)
+
+Para comprobar que el reader y el formato de `sample` funcionan:
+
+```bash
+.venv_sim/bin/python -m gear_sonic.utils.teleop.readers.quest_reader --synthetic --duration 5
+```
+
+Deberías ver algo como: `Last sample: body_poses_np shape (24, 7), fps=~50`.
+
+## Probar Meta Quest (meta_quest_teleop)
+
+Si tienes `meta_quest_teleop` instalado y el APK en el Quest, prueba que llegan datos de los controladores:
+
+```bash
+# Test rápido (solo imprime poses)
+.venv_sim/bin/python gear_sonic/utils/teleop/readers/test_quest_meta_quest.py
+
+# WiFi
+.venv_sim/bin/python gear_sonic/utils/teleop/readers/test_quest_meta_quest.py --ip-address 192.168.x.x
+```
+
+Deberías ver `L:OK R:OK` y posiciones que cambian al mover los mandos.
+
+## Validar datos crudos del Quest (visualización 3D)
+
+Antes de depurar calibración o mapeo al robot, valida que el tracking del Quest sigue correctamente:
+
+```bash
+# USB — visualiza poses en 3D sin calibración
+.venv_teleop/bin/python -m gear_sonic.utils.teleop.readers.validate_quest_raw
+
+# WiFi
+.venv_teleop/bin/python -m gear_sonic.utils.teleop.readers.validate_quest_raw --ip-address 192.168.x.x
+
+# Sin mesh del G1 (solo marcadores VR)
+.venv_teleop/bin/python -m gear_sonic.utils.teleop.readers.validate_quest_raw --no-g1
+```
+
+Mueve los mandos y verifica que la visualización sigue. Si sigue bien → el problema está en calibración/mapeo. Si no sigue → problema en meta_quest_teleop o Quest.
+
+### Modo calibrado (G1 como referencia)
+
+Además del modo raw, `validate_quest_raw` tiene un modo **calibrado** donde la referencia es la pose por defecto del G1 (FK):
+
+```bash
+# Modo calibrado (G1 FK como referencia)
+.venv_teleop/bin/python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated
+
+# Opcional: WiFi + calibrado
+.venv_teleop/bin/python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated --ip-address 192.168.x.x
+```
+
+Flujo recomendado:
+
+- Pon el robot G1 en su **pose por defecto** (la que usa Sonic al iniciar).
+- Adopta **la misma pose** con tu cuerpo/controladores.
+- Pulsa el **trigger derecho** para calibrar.
+- A partir de ahí, la salida es: `pose_G1_default + delta_movimiento_Quest`.
+
+Detalles importantes:
+
+- Sistema de ejes en la visualización:
+  - **X (rojo)**: adelante
+  - **Y (verde)**: izquierda
+  - **Z (azul)**: arriba
+- El reader corrige los ejes que vienen del APK de `meta_quest_teleop` para que:
+  - Adelante/atrás se vea en **X (rojo)**.
+  - Izquierda/derecha se vea en **Y (verde)**.
+  - Arriba/abajo se vea en **Z (azul)**.
+
+## QuestReader con VR 3-point (formato SONIC)
+
+El `QuestReader` con `source="meta_quest"` produce datos en el formato esperado por VR_3PT:
+
+```bash
+# Conectar Quest por USB, pulsar trigger derecho para calibrar
+.venv_sim/bin/python -m gear_sonic.utils.teleop.readers.quest_reader --source meta_quest --duration 30
+
+# WiFi
+.venv_sim/bin/python -m gear_sonic.utils.teleop.readers.quest_reader --source meta_quest --ip-address 192.168.x.x --duration 30
+```
+
+El sample incluye `vr_3pt_pose` (3, 7): L-Wrist, R-Wrist, Head (por defecto). El `PlannerLoop` usa `vr_3pt_pose` directamente cuando está presente.
+
+### Uso dentro de Sonic (pico_manager_thread_server)
+
+Para usar Quest directamente con Sonic (misma calibración y ejes que en `validate_quest_raw`):
+
+```bash
+# Manager de Sonic usando Quest en lugar de Pico
+.venv_sim/bin/python gear_sonic/scripts/pico_manager_thread_server.py \
+    --manager \
+    --reader quest \
+    --quest-ip-address 192.168.x.x   # omitir para USB
+```
+
+Notas:
+
+- `--reader quest` crea un `QuestReader(source="meta_quest")` y le pasa la pose por defecto del G1 (FK) como referencia de calibración.
+- La calibración en Sonic se hace igual: adopta la pose por defecto y pulsa **trigger derecho**.
+- El `vr_3pt_pose` que Sonic envía al planner ya incluye:
+  - La referencia de G1 FK (pose por defecto de muñecas).
+  - La misma corrección de ejes que se ve en `validate_quest_raw`.
+
+## Siguiente paso: conectar datos reales del Quest
+
+Implementa `read_quest_body_via_adb()` en `quest_reader.py` para leer la pose desde tu app/socket/archivo del Quest y devolver un array `(N, 7)` por joint. Luego ejecuta con `--source adb` (y con el reader integrado en `pico_manager_thread_server.py` cuando lo enlaces).

--- a/gear_sonic/utils/teleop/readers/__init__.py
+++ b/gear_sonic/utils/teleop/readers/__init__.py
@@ -1,0 +1,1 @@
+# Teleop body readers (PICO, Quest, etc.)

--- a/gear_sonic/utils/teleop/readers/quest_reader.py
+++ b/gear_sonic/utils/teleop/readers/quest_reader.py
@@ -1,0 +1,542 @@
+"""
+Quest 3 body reader — test connection and stream body pose data.
+
+Use this to:
+  1. Test ADB connection to Quest 3 (run with --test-adb).
+  2. Stream body pose in the same format as PicoReader for pico_manager_thread_server.
+  3. Stream VR 3-point pose (L-Wrist, R-Wrist, Head) from Meta Quest controllers via meta_quest_teleop.
+
+Expected sample format (compatible with PicoReader):
+  body_poses_np: np.ndarray shape (24, 7) — 24 SMPL-like joints, each [x, y, z, qx, qy, qz, qw]
+  (Unity frame, scalar-last quaternion)
+
+For source="meta_quest", sample also includes:
+  vr_3pt_pose: np.ndarray shape (3, 7) — [x, y, z, qw, qx, qy, qz] per row (robot frame)
+  Row 0: Left Wrist, Row 1: Right Wrist, Row 2: Head (default, Quest has no head tracking)
+
+Usage:
+  # Test ADB only
+  python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb
+
+  # Run reader with synthetic data (no Quest needed) to test pipeline
+  python -m gear_sonic.utils.teleop.readers.quest_reader --synthetic
+
+  # Run reader with Meta Quest controllers (meta_quest_teleop)
+  python -m gear_sonic.utils.teleop.readers.quest_reader --source meta_quest
+
+  # Run reader using ADB (implement read_quest_body_via_adb for your app)
+  python -m gear_sonic.utils.teleop.readers.quest_reader --source adb
+"""
+
+import argparse
+import subprocess
+import sys
+import threading
+import time
+
+import numpy as np
+from scipy.spatial.transform import Rotation as sRot
+
+
+# -----------------------------------------------------------------------------
+# ADB connection test
+# -----------------------------------------------------------------------------
+
+def check_adb_connection() -> bool:
+    """Check if ADB is available and at least one device is connected."""
+    try:
+        out = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode != 0:
+            print("[QuestReader] adb devices failed")
+            return False
+        lines = [l.strip() for l in out.stdout.splitlines() if l.strip()]
+        # First line is "List of devices attached"
+        devices = [l for l in lines[1:] if l and not l.startswith("*")]
+        if not devices:
+            print("[QuestReader] No devices found. Connect Quest 3 via USB and enable USB debugging.")
+            return False
+        print(f"[QuestReader] ADB devices: {devices}")
+        return True
+    except FileNotFoundError:
+        print("[QuestReader] 'adb' not found. Install Android platform tools.")
+        return False
+    except subprocess.TimeoutExpired:
+        print("[QuestReader] adb devices timed out")
+        return False
+
+
+def test_adb():
+    """Standalone test: verify ADB and optionally run a shell command."""
+    print("Checking ADB connection to Quest 3...")
+    if not check_adb_connection():
+        sys.exit(1)
+    print("ADB connection OK.")
+    # Optional: run a simple command on device
+    try:
+        out = subprocess.run(
+            ["adb", "shell", "getprop", "ro.product.model"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            print(f"Device model: {out.stdout.strip()}")
+    except Exception as e:
+        print(f"Optional shell check: {e}")
+
+
+# -----------------------------------------------------------------------------
+# Default SMPL-like 24-joint pose (identity / T-pose style)
+# Used when no real data is available (synthetic mode or fallback).
+# -----------------------------------------------------------------------------
+
+def default_smpl_pose_24() -> np.ndarray:
+    """Return a default (24, 7) pose: zeros for position, identity quat for rotation."""
+    pose = np.zeros((24, 7), dtype=np.float32)
+    # Identity quaternion (scalar-last: qx, qy, qz, qw)
+    pose[:, 3:7] = [0.0, 0.0, 0.0, 1.0]
+    # Optional: set root height
+    pose[0, 2] = 1.0
+    return pose
+
+
+# -----------------------------------------------------------------------------
+# VR 3-point pose from Meta Quest controllers (meta_quest_teleop)
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Head reference frame (row 2 of vr_3pt_pose) — Quest has no head tracking, so we use
+# a fixed default. This should match the robot's head position for correct waist/neck
+# calibration. Origin: robot pelvis. Frame: X=forward, Y=left, Z=up (ROS convention).
+#
+# VR_3PT_HEAD_POSITION: [x, y, z] in meters — head position relative to pelvis.
+#   Default from C++ zmq_manager.hpp. For G1: ~0.4m above pelvis, slightly forward.
+#   To use G1 FK: get_g1_key_frame_poses(robot_model)["torso"] + HEAD_LINK_LENGTH.
+#
+# VR_3PT_HEAD_ORIENTATION: [qw, qx, qy, qz] — head orientation (identity ≈ looking forward).
+# -----------------------------------------------------------------------------
+VR_3PT_HEAD_POSITION = np.array([0.0241, -0.0081, 0.4028], dtype=np.float32)
+VR_3PT_HEAD_ORIENTATION = np.array([0.9991, 0.011, 0.0402, -0.0002], dtype=np.float32)  # wxyz
+
+# Home positions for calibration (robot frame, meters) — fallback when G1 FK not available
+META_QUEST_HOME_LEFT = np.array([0.15, 0.25, 0.45])
+META_QUEST_HOME_RIGHT = np.array([0.15, -0.25, 0.45])
+
+
+def _g1_pose_to_4x4(pos: np.ndarray, quat_wxyz: np.ndarray) -> np.ndarray:
+    """Build 4x4 transform from G1 FK pose (position + orientation_wxyz)."""
+    # scipy expects [qx, qy, qz, qw]
+    q_xyzw = np.array([quat_wxyz[1], quat_wxyz[2], quat_wxyz[3], quat_wxyz[0]], dtype=np.float64)
+    R = sRot.from_quat(q_xyzw).as_matrix()
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = pos
+    return T
+
+
+def _matrix_to_quat_wxyz(matrix_3x3: np.ndarray) -> np.ndarray:
+    """Convert 3x3 rotation matrix to quaternion [qw, qx, qy, qz] (scalar-first)."""
+    r = sRot.from_matrix(matrix_3x3)
+    q_xyzw = r.as_quat()  # scipy returns [x, y, z, w]
+    return np.array([q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]], dtype=np.float32)
+
+
+# Permutation: meta_quest axes -> ROS (X=forward, Y=left, Z=up)
+# meta_quest has forward in Z, up in Y, left in X -> we need [z,x,y]
+_QUEST_TO_ROS_P = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
+
+
+def _apply_quest_yz_swap(pose_4x4: np.ndarray) -> np.ndarray:
+    """
+    Correct meta_quest_teleop axes to ROS convention (X=forward, Y=left, Z=up).
+
+    The APK maps: forward->Z, up->Y, left->X. We permute [x,y,z] -> [z,x,y]
+    and negate position to fix inverted directions (forward->back, left->right).
+    """
+    out = pose_4x4.copy()
+    # Position: [x,y,z] -> [z,-x,-y]
+    p = np.array([pose_4x4[2, 3], pose_4x4[0, 3], pose_4x4[1, 3]])
+    out[:3, 3] = [p[0], -p[1], -p[2]]
+    # Rotation: P @ R @ P^T (orientation stays same; position sign flip is enough)
+    R = pose_4x4[:3, :3]
+    out[:3, :3] = _QUEST_TO_ROS_P @ R @ _QUEST_TO_ROS_P.T
+    return out
+
+
+def quest_controllers_to_vr_3pt_pose(
+    left_4x4: np.ndarray | None,
+    right_4x4: np.ndarray | None,
+    head_pos: np.ndarray | None = None,
+    head_quat_wxyz: np.ndarray | None = None,
+) -> np.ndarray:
+    """
+    Convert Meta Quest controller 4x4 poses to VR 3-point pose for SONIC.
+
+    Args:
+        left_4x4: 4x4 transform for left controller (ROS frame = robot frame)
+        right_4x4: 4x4 transform for right controller
+        head_pos: Optional head position [x,y,z]. Default: VR_3PT_HEAD_POSITION
+        head_quat_wxyz: Optional head quat [qw,qx,qy,qz]. Default: VR_3PT_HEAD_ORIENTATION
+
+    Returns:
+        vr_3pt_pose: np.ndarray shape (3, 7) — each row [x, y, z, qw, qx, qy, qz]
+        Row 0: Left Wrist, Row 1: Right Wrist, Row 2: Head (robot head frame, see VR_3PT_HEAD_*)
+    """
+    out = np.zeros((3, 7), dtype=np.float32)
+    head_pos = head_pos if head_pos is not None else VR_3PT_HEAD_POSITION
+    head_quat = head_quat_wxyz if head_quat_wxyz is not None else VR_3PT_HEAD_ORIENTATION
+
+    # Row 0, 1: controller poses (wrists). Row 2: head — fixed default when Quest has no head tracking.
+    # Head frame origin should be at robot head for correct waist/neck calibration.
+    if left_4x4 is not None:
+        out[0, :3] = left_4x4[:3, 3]
+        out[0, 3:7] = _matrix_to_quat_wxyz(left_4x4[:3, :3])
+    else:
+        out[0, :3] = META_QUEST_HOME_LEFT
+        out[0, 3:7] = [1.0, 0.0, 0.0, 0.0]
+
+    if right_4x4 is not None:
+        out[1, :3] = right_4x4[:3, 3]
+        out[1, 3:7] = _matrix_to_quat_wxyz(right_4x4[:3, :3])
+    else:
+        out[1, :3] = META_QUEST_HOME_RIGHT
+        out[1, 3:7] = [1.0, 0.0, 0.0, 0.0]
+
+    # Row 2: Head (robot head frame, see VR_3PT_HEAD_POSITION / VR_3PT_HEAD_ORIENTATION above)
+    out[2, :3] = head_pos
+    out[2, 3:7] = head_quat
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Read body from Quest via ADB (stub — implement with your app)
+# -----------------------------------------------------------------------------
+
+def read_quest_body_via_adb() -> np.ndarray | None:
+    """
+    Read body pose from Quest 3 via ADB.
+
+    Implement according to your setup, for example:
+      - Quest app writes pose to /sdcard/body_pose.bin or .json; adb pull or exec-out cat
+      - Quest app opens TCP server; adb forward tcp:LOCAL tcp:REMOTE, then socket read
+      - Your PC script receives from Quest app over ADB or network
+
+    Returns:
+      np.ndarray shape (N, 7) with [x, y, z, qx, qy, qz, qw] per joint (Quest format).
+      Or None if no data this frame.
+    """
+    # Stub: no real read yet
+    return None
+
+
+def quest_joints_to_smpl_24(quest_joints: np.ndarray) -> np.ndarray:
+    """
+    Map Quest joint array to SMPL-like 24 joints.
+
+    If quest_joints already has 24 rows, use them (optionally reorder).
+    If Quest uses 70 joints (Meta IOBT), map key indices to SMPL 24.
+    """
+    if quest_joints is None or quest_joints.size == 0:
+        return default_smpl_pose_24()
+
+    n = quest_joints.shape[0]
+    smpl = np.zeros((24, 7), dtype=np.float32)
+    smpl[:, 3:7] = [0.0, 0.0, 0.0, 1.0]
+
+    if n >= 24:
+        smpl[:24] = quest_joints[:24]
+        return smpl
+
+    # Minimal mapping for 70-joint Meta format (indices to adjust per Meta docs)
+    # SMPL: 0=root, 12=neck, 22=left_wrist, 23=right_wrist
+    meta_to_smpl = {
+        0: 0,   # Root
+        7: 12,  # Neck (example)
+        24: 22, # Left wrist (example)
+        25: 23, # Right wrist (example)
+    }
+    for meta_idx, smpl_idx in meta_to_smpl.items():
+        if meta_idx < n:
+            smpl[smpl_idx] = quest_joints[meta_idx]
+    return smpl
+
+
+# -----------------------------------------------------------------------------
+# QuestReader — same interface as PicoReader for drop-in use
+# -----------------------------------------------------------------------------
+
+class QuestReader:
+    """
+    Background reader that produces body pose samples compatible with PicoReader.
+
+    Use source="synthetic" to emit dummy poses (for testing pipeline without Quest).
+    Use source="meta_quest" to read controller poses via meta_quest_teleop (VR 3-point format).
+    Use source="adb" to read from Quest via ADB (implement read_quest_body_via_adb).
+    """
+
+    def __init__(
+        self,
+        source: str = "synthetic",
+        max_queue_size: int = 15,
+        ip_address: str | None = None,
+        calibration_threshold: float = 0.5,
+        home_left_pose: np.ndarray | None = None,
+        home_right_pose: np.ndarray | None = None,
+    ):
+        """
+        Args:
+            home_left_pose: 4x4 transform for left wrist reference (G1 FK default).
+                If None, uses META_QUEST_HOME_LEFT (position only).
+            home_right_pose: 4x4 transform for right wrist reference (G1 FK default).
+                If None, uses META_QUEST_HOME_RIGHT (position only).
+        """
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._latest = None
+        self._lock = threading.Lock()
+        self._source = source.lower()
+        self._fps_ema = 0.0
+        self._last_stamp_ns = None
+        self._frame_count = 0
+        self._ip_address = ip_address
+        self._calibration_threshold = calibration_threshold
+        self._home_left_pose = home_left_pose
+        self._home_right_pose = home_right_pose
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        if hasattr(self, "_meta_quest_reader") and self._meta_quest_reader is not None:
+            try:
+                self._meta_quest_reader.stop()
+            except Exception:
+                pass
+
+    def get_latest(self):
+        with self._lock:
+            return self._latest
+
+    def _run_meta_quest(self, t_realtime: float, t_monotonic: float, stamp_ns: int, device_dt: float):
+        """Read from MetaQuestReader and produce vr_3pt_pose sample."""
+        if not hasattr(self, "_meta_quest_reader") or self._meta_quest_reader is None:
+            if getattr(self, "_meta_quest_init_failed", False):
+                return None
+            try:
+                from meta_quest_teleop.reader import MetaQuestReader  # pyright: ignore[reportMissingImports]
+
+                self._meta_quest_reader = MetaQuestReader(
+                    ip_address=self._ip_address,
+                    run=True,
+                )
+                self._left_offset = None
+                self._right_offset = None
+                self._is_calibrated = False
+                self._prev_trigger_pressed = False
+                print("[QuestReader] MetaQuestReader started. Press right trigger to calibrate.")
+            except ImportError as e:
+                print(f"[QuestReader] meta_quest_teleop not installed: {e}")
+                self._meta_quest_init_failed = True
+                return None
+            except SystemExit:
+                print("[QuestReader] MetaQuestReader failed (no device?). Connect Quest via USB/WiFi.")
+                self._meta_quest_init_failed = True
+                self._meta_quest_reader = None
+                return None
+
+        reader = self._meta_quest_reader
+        left_raw = reader.get_hand_controller_transform_ros("left")
+        right_raw = reader.get_hand_controller_transform_ros("right")
+        # Correct Y/Z swap: some Quest APKs map up to Y; we need Z up (ROS convention)
+        if left_raw is not None:
+            left_raw = _apply_quest_yz_swap(left_raw)
+        if right_raw is not None:
+            right_raw = _apply_quest_yz_swap(right_raw)
+        trigger = float(reader.get_trigger_value("right"))
+        trigger_pressed = trigger >= self._calibration_threshold
+
+        # Calibrate on rising edge of trigger
+        if trigger_pressed and not self._prev_trigger_pressed and left_raw is not None and right_raw is not None:
+            try:
+                if self._home_left_pose is not None and self._home_right_pose is not None:
+                    home_left = self._home_left_pose.copy()
+                    home_right = self._home_right_pose.copy()
+                    ref_source = "G1 FK default"
+                else:
+                    home_left = np.eye(4)
+                    home_left[:3, 3] = META_QUEST_HOME_LEFT
+                    home_right = np.eye(4)
+                    home_right[:3, 3] = META_QUEST_HOME_RIGHT
+                    ref_source = "META_QUEST_HOME"
+                self._left_offset = home_left @ np.linalg.inv(left_raw)
+                self._right_offset = home_right @ np.linalg.inv(right_raw)
+                self._is_calibrated = True
+                print(f"[QuestReader] Calibration complete (right trigger, ref={ref_source}).")
+            except np.linalg.LinAlgError:
+                pass
+        self._prev_trigger_pressed = trigger_pressed
+
+        if left_raw is None or right_raw is None:
+            return None
+        if not self._is_calibrated:
+            return None
+
+        left_pose = self._left_offset @ left_raw
+        right_pose = self._right_offset @ right_raw
+        vr_3pt_pose = quest_controllers_to_vr_3pt_pose(left_pose, right_pose)
+
+        # Controller state for manager mode switching (A,B,X,Y, joysticks, triggers, etc.)
+        left_axis = reader.get_joystick_value("left")
+        right_axis = reader.get_joystick_value("right")
+        left_axis = (float(left_axis[0]), float(left_axis[1])) if len(left_axis) >= 2 else (0.0, 0.0)
+        right_axis = (float(right_axis[0]), float(right_axis[1])) if len(right_axis) >= 2 else (0.0, 0.0)
+
+        def _btn(name: str) -> bool:
+            try:
+                return bool(reader.get_button_state(name))
+            except Exception:
+                return False
+
+        # Also provide minimal body_poses_np for compatibility (not used in VR_3PT)
+        body_poses_np = default_smpl_pose_24()
+        body_poses_np[22, :3] = left_pose[:3, 3]
+        body_poses_np[23, :3] = right_pose[:3, 3]
+        q_l = _matrix_to_quat_wxyz(left_pose[:3, :3])
+        q_r = _matrix_to_quat_wxyz(right_pose[:3, :3])
+        body_poses_np[22, 3:7] = [q_l[1], q_l[2], q_l[3], q_l[0]]  # wxyz -> xyzw
+        body_poses_np[23, 3:7] = [q_r[1], q_r[2], q_r[3], q_r[0]]
+
+        return {
+            "body_poses_np": body_poses_np,
+            "vr_3pt_pose": vr_3pt_pose,
+            "timestamp_realtime": t_realtime,
+            "timestamp_monotonic": t_monotonic,
+            "timestamp_ns": stamp_ns,
+            "dt": device_dt,
+            "fps": self._fps_ema,
+            # Controller state for manager (Quest-only)
+            "button_a": _btn("A"),
+            "button_b": _btn("B"),
+            "button_x": _btn("X"),
+            "button_y": _btn("Y"),
+            "left_trigger": float(reader.get_trigger_value("left")),
+            "right_trigger": float(reader.get_trigger_value("right")),
+            "left_grip": float(reader.get_grip_value("left")),
+            "right_grip": float(reader.get_grip_value("right")),
+            "left_axis": left_axis,
+            "right_axis": right_axis,
+            "left_axis_click": _btn("LJ"),
+            "right_axis_click": _btn("RJ"),
+            "left_menu_button": _btn("leftMenu") or _btn("menu") or False,
+        }
+
+    def _run(self):
+        last_report = time.time()
+        while not self._stop.is_set():
+            t_realtime = time.time()
+            t_monotonic = time.monotonic()
+            stamp_ns = int(t_monotonic * 1e9)
+            prev_stamp_ns = self._last_stamp_ns
+            device_dt = (stamp_ns - prev_stamp_ns) * 1e-9 if prev_stamp_ns is not None else 0.0
+            if device_dt > 0:
+                inst = 1.0 / device_dt
+                self._fps_ema = inst if self._fps_ema == 0.0 else (0.9 * self._fps_ema + 0.1 * inst)
+            self._last_stamp_ns = stamp_ns
+
+            sample = None
+            if self._source == "synthetic":
+                body_poses_np = default_smpl_pose_24()
+                self._frame_count += 1
+                body_poses_np[0, 0] = 0.1 * np.sin(self._frame_count * 0.1)
+                sample = {
+                    "body_poses_np": body_poses_np,
+                    "timestamp_realtime": t_realtime,
+                    "timestamp_monotonic": t_monotonic,
+                    "timestamp_ns": stamp_ns,
+                    "dt": device_dt,
+                    "fps": self._fps_ema,
+                }
+            elif self._source == "meta_quest":
+                sample = self._run_meta_quest(t_realtime, t_monotonic, stamp_ns, device_dt)
+            elif self._source == "adb":
+                raw = read_quest_body_via_adb()
+                body_poses_np = quest_joints_to_smpl_24(raw) if raw is not None else None
+                if body_poses_np is not None:
+                    sample = {
+                        "body_poses_np": body_poses_np,
+                        "timestamp_realtime": t_realtime,
+                        "timestamp_monotonic": t_monotonic,
+                        "timestamp_ns": stamp_ns,
+                        "dt": device_dt,
+                        "fps": self._fps_ema,
+                    }
+
+            if sample is not None:
+                with self._lock:
+                    self._latest = sample
+
+            if time.time() - last_report >= 5.0:
+                print(f"[QuestReader] source={self._source} fps={self._fps_ema:.2f}")
+                last_report = time.time()
+
+            time.sleep(0.02)
+
+
+# -----------------------------------------------------------------------------
+# CLI for testing connection and reader
+# -----------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Quest 3 reader — test ADB or run reader")
+    parser.add_argument("--test-adb", action="store_true", help="Only test ADB connection and exit")
+    parser.add_argument("--synthetic", action="store_true", help="Run reader with synthetic data (no Quest)")
+    parser.add_argument(
+        "--source",
+        choices=["adb", "synthetic", "meta_quest"],
+        default="synthetic",
+        help="Reader source (meta_quest uses meta_quest_teleop)",
+    )
+    parser.add_argument("--ip-address", type=str, default=None, help="Quest IP for WiFi (meta_quest only)")
+    parser.add_argument(
+        "--calibration-threshold",
+        type=float,
+        default=0.5,
+        help="Right trigger threshold for calibration (meta_quest, 0-1)",
+    )
+    parser.add_argument("--duration", type=float, default=10.0, help="Run reader for N seconds (default 10)")
+    args = parser.parse_args()
+
+    if args.test_adb:
+        test_adb()
+        return
+
+    source = "synthetic" if args.synthetic else args.source
+    print(f"Starting QuestReader (source={source}) for {args.duration}s...")
+    reader = QuestReader(
+        source=source,
+        ip_address=args.ip_address,
+        calibration_threshold=args.calibration_threshold,
+    )
+    reader.start()
+    try:
+        time.sleep(args.duration)
+        sample = reader.get_latest()
+        if sample is not None:
+            print(f"Last sample: body_poses_np shape {sample['body_poses_np'].shape}, fps={sample['fps']:.2f}")
+            if "vr_3pt_pose" in sample:
+                v = sample["vr_3pt_pose"]
+                print(f"  vr_3pt_pose shape {v.shape}: L={v[0,:3]}, R={v[1,:3]}, H={v[2,:3]}")
+    finally:
+        reader.stop()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/utils/teleop/readers/test_quest_meta_quest.py
+++ b/gear_sonic/utils/teleop/readers/test_quest_meta_quest.py
@@ -1,0 +1,60 @@
+"""Test: verifica que Meta Quest envía poses de controladores via meta_quest_teleop."""
+import argparse
+import sys
+import time
+from pathlib import Path
+
+# Add project root to path (for gear_sonic if needed)
+_ROOT = Path(__file__).resolve().parents[4]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+def main():
+    try:
+        from meta_quest_teleop.reader import MetaQuestReader
+    except ImportError as e:
+        print("[ERROR] meta_quest_teleop no instalado. Ejecuta:")
+        print(
+            "  uv pip install --python .venv_sim/bin/python "
+            "'meta_quest_teleop @ git+https://github.com/BrikHMP18/meta_quest_teleop.git@07bc15437f767c3517138367b6b3e3910b388c76'"
+        )
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Test Meta Quest controller data via meta_quest_teleop")
+    parser.add_argument("--ip-address", type=str, default=None, help="Quest IP for WiFi (omit for USB)")
+    args = parser.parse_args()
+    ip = args.ip_address
+    print(f"[test] Conectando a Quest (ip={ip or 'USB'})...")
+    reader = MetaQuestReader(ip_address=ip, run=True)
+    print("[test] MetaQuestReader iniciado. Mueve los mandos para ver datos...")
+    print("[test] Ctrl+C para parar.\n")
+
+    try:
+        while True:
+            left = reader.get_hand_controller_transform_ros("left")
+            right = reader.get_hand_controller_transform_ros("right")
+            grip_l = reader.get_grip_value("left")
+            grip_r = reader.get_grip_value("right")
+            trig = reader.get_trigger_value("right")
+            js = reader.get_joystick_value("right")
+
+            status = "L:OK" if left is not None else "L:--"
+            status += " R:OK" if right is not None else " R:--"
+            line = f"{status} | grip=({grip_l:.2f},{grip_r:.2f}) trig={trig:.2f} js={js}"
+            if left is not None:
+                pos_l = left[:3, 3]
+                line += f" | L=({pos_l[0]:.2f},{pos_l[1]:.2f},{pos_l[2]:.2f})"
+            if right is not None:
+                pos_r = right[:3, 3]
+                line += f" R=({pos_r[0]:.2f},{pos_r[1]:.2f},{pos_r[2]:.2f})"
+            print(f"\r{line}   ", end="", flush=True)
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        print("\n[test] Parado.")
+    finally:
+        reader.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/utils/teleop/readers/validate_quest_raw.py
+++ b/gear_sonic/utils/teleop/readers/validate_quest_raw.py
@@ -1,0 +1,255 @@
+"""
+Validate Quest raw tracking data — visualize with or without calibration.
+
+Reads controller poses from meta_quest_teleop and displays them in a 3D PyVista window.
+Use this to verify Quest tracking and test the G1-based calibration flow.
+
+Modes:
+  - Raw (default): No calibration. Verifies that Quest tracking follows correctly.
+  - Calibrated (--calibrated): Use G1 FK default as reference. Press right trigger
+    to calibrate; then output = G1_default + delta from calibration pose.
+
+Usage:
+  # USB connection, raw mode
+  python -m gear_sonic.utils.teleop.readers.validate_quest_raw
+
+  # WiFi (Quest IP)
+  python -m gear_sonic.utils.teleop.readers.validate_quest_raw --ip-address 192.168.x.x
+
+  # Calibrated mode: adopt G1 default pose, press right trigger, then move
+  python -m gear_sonic.utils.teleop.readers.validate_quest_raw --calibrated
+
+  # Run for 30 seconds then exit
+  python -m gear_sonic.utils.teleop.readers.validate_quest_raw --duration 30
+
+  # Update rate (default 50 Hz)
+  python -m gear_sonic.utils.teleop.readers.validate_quest_raw --hz 50
+
+Press Ctrl+C or close the window to exit.
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# Add project root for imports
+_ROOT = Path(__file__).resolve().parents[4]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate Quest tracking — raw or calibrated (G1 FK reference)"
+    )
+    parser.add_argument(
+        "--ip-address",
+        type=str,
+        default=None,
+        help="Quest IP for WiFi (omit for USB)",
+    )
+    parser.add_argument(
+        "--hz",
+        type=float,
+        default=50.0,
+        help="Update rate in Hz (default 50)",
+    )
+    parser.add_argument(
+        "--no-g1",
+        action="store_true",
+        help="Hide G1 robot mesh (show only VR pose markers)",
+    )
+    parser.add_argument(
+        "--calibrated",
+        action="store_true",
+        help="Use G1 FK default as calibration reference. Press right trigger to calibrate.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=0.0,
+        help="Run for N seconds then exit (0 = run until Ctrl+C)",
+    )
+    args = parser.parse_args()
+
+    # Import meta_quest_teleop
+    try:
+        from meta_quest_teleop.reader import MetaQuestReader  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        print("[ERROR] meta_quest_teleop no instalado. Ejecuta:")
+        print("  bash install_scripts/install_pico.sh")
+        print("  o: pip install 'meta_quest_teleop @ git+https://github.com/BrikHMP18/meta_quest_teleop.git@07bc15437f767c3517138367b6b3e3910b388c76'")
+        sys.exit(1)
+
+    from gear_sonic.utils.teleop.readers.quest_reader import (
+        quest_controllers_to_vr_3pt_pose,
+        _g1_pose_to_4x4,
+        _apply_quest_yz_swap,
+    )
+
+    try:
+        from gear_sonic.utils.teleop.vis.vr3pt_pose_visualizer import (
+            VR3PtPoseVisualizer,
+            get_g1_key_frame_poses,
+        )
+    except ImportError as e:
+        print(f"[ERROR] VR3PtPoseVisualizer no disponible: {e}")
+        print("  Instala pyvista: pip install pyvista")
+        sys.exit(1)
+
+    # Load G1 model for calibrated mode
+    home_left_4x4 = None
+    home_right_4x4 = None
+    robot_model = None
+    if args.calibrated:
+        try:
+            from gear_sonic.data.robot_model.instantiation.g1 import (
+                instantiate_g1_robot_model,
+            )
+
+            robot_model = instantiate_g1_robot_model()
+            g1_poses = get_g1_key_frame_poses(robot_model)
+            home_left_4x4 = _g1_pose_to_4x4(
+                g1_poses["left_wrist"]["position"],
+                g1_poses["left_wrist"]["orientation_wxyz"],
+            )
+            home_right_4x4 = _g1_pose_to_4x4(
+                g1_poses["right_wrist"]["position"],
+                g1_poses["right_wrist"]["orientation_wxyz"],
+            )
+        except Exception as e:
+            print(f"[ERROR] No se pudo cargar G1 para modo calibrado: {e}")
+            sys.exit(1)
+
+    print("=" * 60)
+    print("Quest Tracking Validation")
+    print("=" * 60)
+    print("Conectando a Quest...")
+    if args.calibrated:
+        print("  Modo: CALIBRADO (G1 FK como referencia)")
+        print("  - Adopta la pose por defecto del G1 (muñecas como el robot)")
+        print("  - Pulsa trigger derecho para calibrar")
+        print("  - Luego mueve: output = G1_default + delta")
+    else:
+        print("  Modo: RAW (sin calibración)")
+        print("  - Datos crudos del Quest")
+        print("  - Si sigue bien → problema en calibración/mapeo")
+        print("  - Si no sigue → problema en meta_quest_teleop o Quest")
+    if args.duration > 0:
+        print(f"  Duración: {args.duration}s")
+    print("=" * 60)
+
+    reader = MetaQuestReader(ip_address=args.ip_address, run=True)
+    dt = 1.0 / max(1.0, args.hz)
+
+    visualizer = VR3PtPoseVisualizer(
+        axis_length=0.08,
+        ball_radius=0.015,
+        with_g1_robot=not args.no_g1,
+        robot_model=robot_model,
+    )
+    visualizer.create_realtime_plotter(interactive=True)
+
+    # Calibration state (for --calibrated mode)
+    left_offset = None
+    right_offset = None
+    is_calibrated = False
+    prev_trigger_pressed = False
+    calibration_threshold = 0.5
+
+    last_status = 0.0
+    frame_count = 0
+    fps_ema = 0.0
+    last_stamp = time.monotonic()
+    start_time = time.time()
+
+    try:
+        while visualizer.is_open:
+            t_now = time.monotonic()
+            device_dt = t_now - last_stamp
+            if device_dt > 0:
+                inst_fps = 1.0 / device_dt
+                fps_ema = inst_fps if fps_ema == 0.0 else (0.9 * fps_ema + 0.1 * inst_fps)
+            last_stamp = t_now
+
+            left_raw = reader.get_hand_controller_transform_ros("left")
+            right_raw = reader.get_hand_controller_transform_ros("right")
+            # Correct Y/Z swap: Quest APK maps up to Y; we need Z up (ROS convention)
+            if left_raw is not None:
+                left_raw = _apply_quest_yz_swap(left_raw)
+            if right_raw is not None:
+                right_raw = _apply_quest_yz_swap(right_raw)
+            trigger = float(reader.get_trigger_value("right"))
+            trigger_pressed = trigger >= calibration_threshold
+
+            # Calibrate on rising edge (calibrated mode only)
+            if args.calibrated and trigger_pressed and not prev_trigger_pressed:
+                if (
+                    left_raw is not None
+                    and right_raw is not None
+                    and home_left_4x4 is not None
+                    and home_right_4x4 is not None
+                ):
+                    try:
+                        left_offset = home_left_4x4 @ np.linalg.inv(left_raw)
+                        right_offset = home_right_4x4 @ np.linalg.inv(right_raw)
+                        is_calibrated = True
+                        print("\n[validate] Calibración completada (trigger derecho). Ref=G1 FK default.")
+                    except np.linalg.LinAlgError:
+                        pass
+            prev_trigger_pressed = trigger_pressed
+
+            # Build vr_3pt_pose
+            if (
+                args.calibrated
+                and is_calibrated
+                and left_offset is not None
+                and right_offset is not None
+                and left_raw is not None
+                and right_raw is not None
+            ):
+                left_pose = left_offset @ left_raw
+                right_pose = right_offset @ right_raw
+                vr_3pt_pose = quest_controllers_to_vr_3pt_pose(left_pose, right_pose)
+            else:
+                vr_3pt_pose = quest_controllers_to_vr_3pt_pose(left_raw, right_raw)
+
+            visualizer.update_vr_poses(vr_3pt_pose)
+            visualizer.render()
+
+            frame_count += 1
+            now = time.time()
+            if now - last_status >= 2.0:
+                status = "L:OK" if left_raw is not None else "L:--"
+                status += " R:OK" if right_raw is not None else " R:--"
+                if left_raw is not None:
+                    pos = left_raw[:3, 3]
+                    status += f" | L=({pos[0]:.2f},{pos[1]:.2f},{pos[2]:.2f})"
+                if right_raw is not None:
+                    pos = right_raw[:3, 3]
+                    status += f" R=({pos[0]:.2f},{pos[1]:.2f},{pos[2]:.2f})"
+                calib_str = " [CALIB]" if (args.calibrated and is_calibrated) else ""
+                status += f" | {fps_ema:.1f} Hz | frames={frame_count}{calib_str}"
+                print(f"\r[validate] {status}   ", end="", flush=True)
+                last_status = now
+
+            # Duration limit
+            if args.duration > 0 and (now - start_time) >= args.duration:
+                print(f"\n[validate] Duración {args.duration}s alcanzada.")
+                break
+
+            time.sleep(dt)
+
+    except KeyboardInterrupt:
+        print("\n[validate] Interrumpido por usuario.")
+    finally:
+        reader.stop()
+        visualizer.close()
+        print("[validate] Listo.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/utils/teleop/vis/vr3pt_pose_visualizer.py
+++ b/gear_sonic/utils/teleop/vis/vr3pt_pose_visualizer.py
@@ -843,6 +843,7 @@ class VR3PtPoseVisualizer:
     WORLD_BALL_COLOR = "white"
 
     # VR pose ball colors - order: [0]=L-Wrist, [1]=R-Wrist, [2]=Head
+    # Row 2 (Head) = robot head frame; for Quest uses VR_3PT_HEAD_* default (quest_reader.py)
     VR_BALL_COLORS = ["lightgreen", "lightblue", "orange"]
     VR_POSE_LABELS = ["L-Wrist", "R-Wrist", "Head"]
 


### PR DESCRIPTION
# Add Meta Quest 3 teleoperation support

## Summary

This PR adds **Meta Quest 3** as an alternative input device for the GEAR-SONIC teleoperation system. Users can run the manager with Quest controllers (USB or WiFi) in addition to the existing Pico-based flow. The default remains Pico; Quest is opt-in via `--reader quest`.

## Changes

- **Quest reader** (`gear_sonic/utils/teleop/readers/quest_reader.py`): New `QuestReader` that implements the same sample interface as `PicoReader`. Uses `meta_quest_teleop` to read controller poses, maps them to the existing VR 3-point pose format (L-Wrist, R-Wrist, Head), and corrects Quest coordinate axes to the robot frame (X=forward, Y=left, Z=up). Supports USB and WiFi (`--quest-ip-address`), calibration via right trigger, and optional ADB/synthetic modes for testing.
- **Manager integration** (`gear_sonic/scripts/pico_manager_thread_server.py`): New CLI options `--reader {pico|quest}` (default: `pico`) and `--quest-ip-address`. When `--reader quest`, the manager uses `QuestReader` and reads controller state (A/B/X/Y, triggers, grips, joysticks) from the Quest sample for mode switching and locomotion. Calibration uses G1 FK default pose as reference, same as the validation script.
- **Validation and testing**: `validate_quest_raw` for 3D visualization of Quest tracking (raw or G1-calibrated), and `test_quest_meta_quest.py` for a quick connection check. ADB test via `python -m gear_sonic.utils.teleop.readers.quest_reader --test-adb`.
- **Dependencies**: Optional dependency `meta_quest_teleop` added under the existing `gear_sonic[teleop]` extra in `pyproject.toml`.
- **Docs**: Setup guide for Quest 3 (requirements, ADB, calibration, full sim + deploy + Quest workflow) in `TELEOPERATION_QUEST_SETUP.md` and reader usage in `gear_sonic/utils/teleop/readers/README.md`.

## Backward compatibility

- **Pico unchanged**: Default reader is `pico`. All Pico code paths (XRoboToolkit, body tracking, SMPL 3-point pose) are unchanged. Existing users continue to use the same commands without modification.
- **Quest is additive**: No breaking changes to existing APIs or CLI; Quest is selected only when `--reader quest` is passed.

## How to use (Quest)

```bash
# USB (recommended for first use)
python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest

# WiFi
python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest --quest-ip-address 192.168.x.x

# With VR 3-point visualization
python gear_sonic/scripts/pico_manager_thread_server.py --manager --reader quest --vis_vr3pt
```

Connect the Quest, start the manager, then press **right trigger** to calibrate (adopt G1 default pose first). See `TELEOPERATION_QUEST_SETUP.md` for full setup (ADB, developer mode, install).

## Tested

- Meta Quest 3 hardware (controllers, USB and WiFi)
- Ubuntu 22.04

This allows using the teleoperation system with Meta Quest 3 devices in addition to Pico, without affecting existing Pico users.
