### PR TITLE
New Embodiment : support for Agibot-X2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,7 @@ models/
 # Downloaded from HuggingFace (hf download)
 sample_data/
 sonic_release/
+
+# Agibot X2 (local reference material & notes; not tracked for now)
+agibot-x2-references/
+agibot_x2_embodiment.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,7 @@ Documentation
    user_guide/training
    user_guide/training_data
    user_guide/new_embodiments
+   user_guide/sim2sim_mujoco
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/references/conventions.md
+++ b/docs/source/references/conventions.md
@@ -140,3 +140,32 @@ automatically via `order_converter.py`.
 
 See [Training on New Embodiments](../user_guide/new_embodiments.md) for how to
 define these mappings for a new robot.
+
+### Traversal order details
+
+| Framework | Traversal | Sibling order |
+|-----------|-----------|---------------|
+| MuJoCo | DFS (depth-first) | XML element order |
+| Isaac Lab (URDF importer) | BFS (breadth-first) | **Alphabetical** by joint/link name |
+| PyBullet | DFS | URDF element order |
+
+**The alphabetical sibling sort in Isaac Lab is the most common source of
+mapping bugs.** It means the Isaac Lab joint order does **not** follow the order
+joints appear in the URDF XML. For example, if `torso_link` has children
+`left_shoulder_pitch_link`, `right_shoulder_pitch_link`, and `head_yaw_link`,
+Isaac Lab will order them as `head_yaw_link` (h), `left_shoulder_pitch_link` (l),
+`right_shoulder_pitch_link` (r) — regardless of their XML order.
+
+### How to verify mappings
+
+**Never hand-derive mapping arrays from the URDF XML.** Instead:
+
+1. Load the URDF in Isaac Lab, print `robot.joint_names` to get the actual order.
+2. Load the MJCF in MuJoCo, inspect `model.joint(i).name` for each index.
+3. Build the mapping arrays by matching names between the two lists.
+4. Validate by loading a known motion in both simulators and visually comparing.
+
+If the arrays are wrong, the robot will still move (no runtime error), but joints
+will be scrambled — limbs receive each other's target angles. Legs and waist
+tend to look correct because they are deep in the tree and often agree between
+DFS and BFS; arms and head are typically where mismatches appear.

--- a/docs/source/user_guide/new_embodiments.md
+++ b/docs/source/user_guide/new_embodiments.md
@@ -86,8 +86,22 @@ H2_ISAACLAB_TO_MUJOCO_MAPPING = {
 ```
 
 **Getting the mappings right is critical.** If they are wrong, the policy will
-receive scrambled observations and produce scrambled actions. Verify by loading a
-known pose in both simulators and checking that joint values match after reordering.
+receive scrambled observations and produce scrambled actions. The bug is silent —
+no runtime error, the robot simply moves wrong.
+
+> **Warning: Do not hand-derive the Isaac Lab joint order from the URDF XML.**
+> Isaac Lab's URDF importer uses BFS traversal with **alphabetical sibling
+> sorting**. This means children of the same parent are ordered by link name
+> (`head` before `left` before `right`), not by their position in the XML file.
+> MuJoCo uses DFS in XML order. The two orderings can differ substantially,
+> especially for arms and head joints that branch from the torso.
+>
+> Always obtain the Isaac Lab order empirically by printing `robot.joint_names`
+> at runtime. See [Joint Ordering in Conventions](../references/conventions.md#joint-ordering)
+> for details.
+
+Verify by loading a known motion (e.g. a walk clip) in both MuJoCo viewer and
+Isaac Lab, and visually confirming that the arms, head, and legs all match.
 
 ### Actuator parameters (KP/KD tuning)
 

--- a/docs/source/user_guide/sim2sim_mujoco.md
+++ b/docs/source/user_guide/sim2sim_mujoco.md
@@ -1,0 +1,305 @@
+# Sim-to-Sim: Deploying a Trained Policy in MuJoCo
+
+This guide documents how to take a SONIC checkpoint trained in IsaacLab
+and run it in MuJoCo for closed-loop evaluation, plus the collection of
+subtle IsaacLab↔MuJoCo mismatches we hit doing exactly that for the
+Agibot X2 Ultra. Every gotcha listed here was a real bug that produced
+visually-plausible but completely broken behavior; check this list first
+when porting a new embodiment.
+
+The reference implementation is `gear_sonic/scripts/eval_x2_mujoco.py`.
+The script is X2-specific in the sense that it loads X2's MJCF, default
+pose, gain table, and DOF mappings — but the structure (RSI →
+proprioception buffer → tokenizer obs → actor → PD → auto-reset) is
+identical for any embodiment. Use it as the template.
+
+## Quick Start
+
+```bash
+conda run -n env_isaaclab --no-capture-output python gear_sonic/scripts/eval_x2_mujoco.py \
+    --checkpoint logs_rl/<run>/model_step_NNNNNN.pt \
+    --motion gear_sonic/data/motions/<robot>_<motion>.pkl
+```
+
+Useful flags:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--init-frame N` | 0 | RSI motion frame to teleport into at every reset |
+| `--fall-height H` | 0.4 m | Pelvis-z below this triggers an auto-reset |
+| `--fall-tilt-cos C` | -0.3 | `gravity_body[z]` above this triggers an auto-reset (~72° tilt) |
+| `--max-episode T` | 0 | If > 0, force-reset every T simulated seconds |
+| `--speed S` | 1.0 | Motion phase speed multiplier |
+| `--device` | cpu | Inference device for the actor |
+
+Viewer controls: `SPACE` pause/resume, `R` manual reset, `V` toggle
+tracking/free camera.
+
+## How the Script Mirrors IsaacLab
+
+The deployment loop reproduces what IsaacLab does on every episode:
+
+1. **Reference State Initialization (RSI)** — at every reset, the robot
+   is teleported to the motion's `--init-frame` state. This sets root
+   pos/quat/lin_vel/ang_vel and joint pos/vel from the motion library.
+2. **Closed-loop control** — each control tick the script reads MuJoCo
+   state, builds the IsaacLab-format proprioception (history of the
+   last `HISTORY_LEN` ticks) and tokenizer (next `NUM_FUTURE_FRAMES`
+   reference frames in the body frame) observations, runs the actor
+   (encoder + FSQ + decoder), and applies explicit PD control to track
+   the policy's joint targets.
+3. **Auto-reset on fall** — when the pelvis drops below
+   `--fall-height` or the body tilts past `--fall-tilt-cos` the
+   episode resets back to RSI. This is a coarser, height-based trigger
+   than IsaacLab's tracking-error terminations used during training,
+   so episode lengths in the viewer are **not** comparable to
+   training/eval episode lengths — the deployment script lets the
+   policy survive bad-tracking states that training would have
+   terminated.
+
+## Critical Gotchas
+
+### G1. MuJoCo free-joint `qvel` is NOT all in world frame
+
+This is the single most important pitfall. For a free joint:
+
+| Slot | Frame |
+|---|---|
+| `qvel[0:3]` (linear) | **World** frame |
+| `qvel[3:6]` (angular) | **Body-local** frame (NOT world!) |
+
+This bites in two places:
+
+1. **RSI write** — motion-lib stores `root_ang_vel_w` in world frame.
+   You must convert to body before writing:
+   ```python
+   mj_data.qvel[3:6] = quat_rotate_inverse(root_quat_w_wxyz, root_ang_vel_w)
+   ```
+2. **Per-step proprioception** — IsaacLab's `base_ang_vel` term is
+   already in the body frame. Read `mj_data.qvel[3:6]` directly and
+   do **not** rotate by `quat_rotate_inverse(base_quat, ...)`. The
+   wrong-assumption rotation produces a *double* rotation, corrupting
+   the angular-velocity history every step. Symptom: policy looks
+   confused, drifts off balance after a stride, never recovers — but
+   the same checkpoint walks fine in IsaacLab.
+
+Verification recipe: zero-gravity single-body MJCF, set `qvel[3:6]`,
+let the sim integrate one timestep, and check how `qpos[3:7]` evolves
+relative to body-frame and world-frame hypotheses.
+
+### G2. Quaternion convention: wxyz everywhere, xyzw for SciPy only
+
+- IsaacLab and MuJoCo both use **wxyz** (scalar-first) quaternions.
+- `scipy.spatial.transform.Rotation.from_quat` / `as_quat` use **xyzw**
+  (scalar-last) — a constant source of off-by-90° rotations.
+- Use a `quat_rotate_inverse` that matches IsaacLab's `quat_apply_inverse`
+  exactly. Don't substitute a SciPy-derived helper without converting
+  the quaternion order, and double-check the sign convention. A sign-flip
+  bug will make gravity in the body frame point *up* instead of down;
+  symptom: the robot tries to stand on its head.
+
+### G3. DOF reordering is required and the gather-index naming is confusing
+
+IsaacLab and MuJoCo traverse the kinematic tree in different orders.
+Maintain two index permutations in your embodiment file (e.g.
+`gear_sonic/envs/manager_env/robots/<robot>.py`):
+
+```python
+# Gather index: result[il_pos] = source[IL_TO_MJ_DOF[il_pos]]
+IL_TO_MJ_DOF = [...]   # used to convert MJ→IL
+MJ_TO_IL_DOF = [...]   # used to convert IL→MJ
+```
+
+The naming describes "where to *gather from*", not "where to map to":
+
+- **MJ → IL (state read):** `dof_pos_il = dof_pos_mj[IL_TO_MJ_DOF]`
+- **IL → MJ (action write):** `action_mj = action_il[MJ_TO_IL_DOF]`
+
+We had these swapped early on. The symptom was huge correlated
+joint motion — the wrong permutation is still a meaningful permutation,
+just with totally different per-joint meanings. When in doubt set up a
+sentinel test: write a known per-joint pattern, round-trip it, and
+verify you get back what you started with.
+
+### G4. Default joint pose, action scale, and PD gains all matter
+
+Pull these from the embodiment file:
+
+- **`DEFAULT_JOINT_POS`** is the home pose. Joint targets are
+  `target = DEFAULT_DOF + action * ACTION_SCALE`, **not** raw
+  `action * ACTION_SCALE`. Forgetting the offset gives the policy a
+  zero-initialized pose where (e.g.) knees are straight, leading to
+  instant collapse on contact.
+- **`ACTION_SCALE`** is per-joint. Typical humanoid configs use
+  large values for hip/knee (~0.5) and smaller values for arms
+  (~0.25). A single global scalar will keep the robot alive but
+  produces noticeably stiff arms and over-driven legs.
+- **`KP` / `KD`** must be derived the same way IsaacLab's implicit
+  actuator computes them internally (stiffness + armature
+  contribution). Do **not** copy raw `effort_limits` or `damping`
+  from the actuator config and use them directly as PD gains.
+
+### G5. Implicit (IsaacLab) vs explicit (MuJoCo) actuator
+
+IsaacLab's PD runs implicitly with armature on the inertia matrix.
+MuJoCo's `ctrl`-driven PD is explicit. With low arm/waist KP
+(weak by design — many SONIC robots have ~14 N·m/rad on upper-body
+joints) the difference is observable: explicit MuJoCo cannot hold
+the upper body up against gravity by itself, and the policy is
+expected to add the gravity-comp torque.
+
+This is **not something you "fix"** in deployment — it's a known
+sim gap. Practical implications:
+
+- Do not expect the robot to hold its default pose under a zero
+  action. IsaacLab can; MuJoCo cannot.
+- Once the policy is trained well, sag disappears (the policy adds
+  the needed torque). With a weakly-trained checkpoint you may see
+  the upper body lean even though the legs walk.
+
+### G6. Proprioception layout follows the dataclass, not the YAML
+
+The flat proprioception vector is **not** in YAML order — it's in
+`PolicyCfg` dataclass attribute order
+(`gear_sonic/envs/manager_env/mdp/observations.py`):
+
+```
+[base_ang_vel, joint_pos_rel, joint_vel, last_action, gravity_dir]
+```
+
+Each term is concatenated across `history_length` frames,
+**oldest-first** within the term. For an embodiment with `N` DOF and
+`history_length=10` the layout is:
+
+| Term | Per-frame | × history | Block size |
+|---|---|---|---|
+| `base_ang_vel` | 3 | 10 | 30 |
+| `joint_pos_rel` | N | 10 | 10·N |
+| `joint_vel` | N | 10 | 10·N |
+| `last_action` | N | 10 | 10·N |
+| `gravity_dir` | 3 | 10 | 30 |
+
+Total: `60 + 30·N`. (For X2: 60 + 30·31 = **990**.)
+
+A wrong term order produces nicely-numerically-ranged garbage. Use
+`gear_sonic/scripts/dump_isaaclab_step0.py` to dump IsaacLab's
+proprioception at step 0, then slice each block in your MuJoCo build
+and verify the values match the corresponding `env_state` quantity
+within the configured noise tolerance.
+
+### G7. CircularBuffer reset broadcast-fills with the first observation
+
+IsaacLab's `CircularBuffer` does **not** initialize history to zeros.
+On reset it *broadcast-fills* every history slot with whatever the
+first appended observation is. Replicate this:
+
+```python
+def append(self, ...):
+    if not self._primed:
+        for _ in range(HISTORY_LEN):
+            self._hist.append(obs)   # for each term
+        self._primed = True
+    else:
+        self._hist.append(obs)       # for each term
+```
+
+Wrong behavior (zero-initialized history): the policy makes huge
+corrections in the first few control ticks because the `last_action`
+history is artificially zero, even though the at-rest action would
+have produced a finite value. The robot wobbles for the first
+~200 ms of every episode then either settles or explodes.
+
+### G8. FSQ quantization layer in the actor forward path
+
+The universal-token actor's tokenizer encoder output is passed
+through a Finite Scalar Quantizer (FSQ) — a `tanh`-then-round-to-bin
+step. The checkpoint stores the FSQ levels but a naive forward
+through encoder + decoder does **not** apply it automatically. You
+must insert it explicitly:
+
+```python
+def fsq_quantize(z, levels):
+    # z: (B, num_tokens * token_dim)
+    bound = (levels - 1) * 0.5
+    z_bounded = bound * torch.tanh(z)
+    z_quant = torch.round(z_bounded) / bound
+    return z_quant
+```
+
+Read the FSQ levels from the checkpoint config (look for
+`quantizer.levels`). Without quantization the policy works
+marginally — actions are continuous and slightly off, the robot
+wobbles but doesn't catastrophically fail. With it, the policy
+matches its trained behavior.
+
+### G9. Tokenizer observation: future reference in the *current* body frame
+
+The tokenizer encoder consumes a flattened sequence of the next
+`num_future_frames` reference frames. Each frame's data
+(`command_multi_future_nonflat`, `motion_anchor_ori_b_mf_nonflat`,
+etc. — depends on the encoder config) is expressed in the **current**
+body frame, not world frame. The reference frame is captured at the
+*current* control tick, so each tokenizer obs is a fresh body-frame
+projection of the same world-frame motion clip — repeating the
+projection every tick is correct.
+
+For X2 with 10 future frames at 0.1 s spacing the total dim is
+`10 × 68 = 680`. Frame width depends on the tokenizer observation
+group; see `gear_sonic/config/manager_env/observations/tokenizer/`.
+
+### G10. RSI is the proper reset, not a clean spawn
+
+IsaacLab does **not** start episodes with the robot standing in its
+default pose at the origin. It teleports the entire robot — joints
++ root — to a sampled motion frame's state. This means:
+
+- The first proprioception observation already has motion-correct
+  joint velocities and base angular velocity.
+- The "first action" the policy ever sees comes from a mid-stride
+  state, not a stationary one.
+
+If you spawn the robot at the default pose and let physics settle,
+the first ~10 frames of proprioception will be wildly out-of-distribution
+relative to training, and the policy will produce huge actions trying
+to "fix" the imagined error. The deployment script uses RSI by default;
+keep it that way unless you have a specific reason not to.
+
+## Debugging Recipe: When IsaacLab Works but MuJoCo Doesn't
+
+1. **Dump the IsaacLab step-0 ground truth** with
+   `gear_sonic/scripts/dump_isaaclab_step0.py`. It writes the full
+   proprio vector, tokenizer obs, encoder/FSQ/decoder activations,
+   and the final action to a `.pt` file.
+2. In the MuJoCo loop, after RSI but before the first policy call,
+   build the same observations and compare:
+   - **Proprioception**: each block (per the G6 layout) should match
+     the corresponding `env_state` quantity within IsaacLab's
+     observation noise tolerance.
+   - **Tokenizer obs**: should match exactly (no noise at step 0).
+   - **Encoder output, FSQ output, decoder output, final action**:
+     each should match within a few `1e-3` (FSQ rounding + float32
+     differences).
+3. Whichever block diverges first tells you exactly which side of the
+   pipeline has the bug.
+
+## Symptom → Likely Cause
+
+| Symptom | First place to look |
+|---|---|
+| Robot collapses immediately on reset | Default pose + action-scale offset (G4); RSI not applied (G10) |
+| Robot stands but tips over slowly | Implicit-vs-explicit actuator (G5); upper-body sag — sometimes expected |
+| Robot walks one stride then falls | qvel angular frame (G1); proprio term order (G6); buffer not primed (G7) |
+| Wild whole-body motion, looks "possessed" | DOF reorder direction swapped (G3); FSQ missing (G8) |
+| Robot tries to stand on its head | Quaternion sign convention or `quat_rotate_inverse` direction (G2) |
+| Arms float, legs over-respond | Single global action-scale instead of per-joint (G4) |
+| Walks fine for ~1 s then drifts | Tokenizer obs body-frame transform off (G9); motion phase clock not aligned with RSI frame (G10) |
+| Same checkpoint walks in IsaacLab, fails in MuJoCo | Always start with the dump-and-compare recipe above |
+
+## See Also
+
+- `gear_sonic/scripts/eval_x2_mujoco.py` — reference deployment script
+- `gear_sonic/scripts/dump_isaaclab_step0.py` — IsaacLab GT dumper
+- `gear_sonic/envs/manager_env/robots/x2_ultra.py` — example embodiment config
+- {doc}`new_embodiments` — adding a new robot from scratch
+- {doc}`../references/conventions` — coordinate / quaternion / DOF conventions
+- {doc}`../references/observation_config` — full observation-group reference

--- a/gear_sonic/config/actor_critic/universal_token/x2_teleop_mlp_v1.yaml
+++ b/gear_sonic/config/actor_critic/universal_token/x2_teleop_mlp_v1.yaml
@@ -1,0 +1,60 @@
+# @package _global_
+# X2 Ultra actor-critic: 2 encoders (motion tracking + teleop), no SMPL encoder.
+
+defaults:
+  - critics/mlp@algo.config.critic
+  - quantizers/fsq@algo.config.actor.backbone.quantizer
+  # encoders
+  - encoders/g1_mf_mlp@algo.config.actor.backbone.encoders
+  - encoders/teleop_mlp@algo.config.actor.backbone.encoders
+  # decoders
+  - decoders/g1_dyn_mlp@algo.config.actor.backbone.decoders
+  - decoders/g1_kin_mf_mlp@algo.config.actor.backbone.decoders
+
+manager_env:
+  commands:
+    motion:
+      encoder_sample_probs:
+        g1: 1.0
+        teleop: 1.0
+
+algo:
+  config:
+    actor:
+      _target_: gear_sonic.trl.modules.actor_critic_modules.Actor
+      running_mean_std: false
+      input_obs_dict: true
+      has_aux_loss: true
+      backbone:
+        _target_: gear_sonic.trl.modules.universal_token_modules.UniversalTokenModule
+        num_future_frames: ${manager_env.commands.motion.num_future_frames}
+        proprioception_features: ["actor_obs"]
+        encoder_sample_probs: ${manager_env.commands.motion.encoder_sample_probs}
+        num_fsq_levels: 32
+        fsq_level_list: 32
+        max_num_tokens: 2
+        encoders:
+          g1:
+            inputs:
+              [
+                "command_multi_future_nonflat",
+                "motion_anchor_ori_b_mf_nonflat",
+                "command_z_multi_future_nonflat",
+              ]
+          teleop:
+            inputs:
+              [
+                "command_multi_future_lower_body",
+                "vr_3point_local_target",
+                "vr_3point_local_orn_target",
+                "motion_anchor_ori_b",
+                "command_z",
+              ]
+        decoders:
+          g1_kin:
+            outputs:
+              [
+                "command_multi_future_nonflat",
+                "motion_anchor_ori_b_mf_nonflat",
+                "command_z_multi_future_nonflat",
+              ]

--- a/gear_sonic/config/aux_losses/universal_token/x2_recon_and_teleop_latent.yaml
+++ b/gear_sonic/config/aux_losses/universal_token/x2_recon_and_teleop_latent.yaml
@@ -1,0 +1,10 @@
+# @package algo.config.actor.backbone
+# X2 Ultra aux losses: reconstruction + motion-teleop latent alignment (no SMPL losses).
+
+defaults:
+  - terms/g1_recon@aux_loss_func
+  - terms/g1_teleop_latent@aux_loss_func
+
+aux_loss_coef:
+  g1_recon: 0.01
+  g1_teleop_latent: 1.0

--- a/gear_sonic/config/exp/manager/universal_token/all_modes/sonic_x2_ultra.yaml
+++ b/gear_sonic/config/exp/manager/universal_token/all_modes/sonic_x2_ultra.yaml
@@ -1,0 +1,104 @@
+# @package _global_
+# SONIC X2 Ultra config — 3 encoders (G1/motion tracking, teleop, SMPL) for Agibot X2 Ultra.
+# Based on sonic_h2 but targeting the X2 Ultra robot (32 bodies, 31 DOF).
+
+defaults:
+  - /algo: ppo_im_phc
+  - /manager_env: base_env
+  - /callbacks/read_eval
+  - /callbacks/im_resample
+  - /aux_losses: universal_token/g1_recon_and_all_latent
+  - override /trainer: trl_ppo_aux
+  - override /actor_critic: universal_token/all_mlp_v1
+  - override /manager_env/observations/tokenizer: unitoken_all_noz
+  - override /manager_env/observations/policy: local_dir_hist
+  - override /manager_env/observations/critic: privileged_mf_hist
+  - override /manager_env/events: tracking/level0_4
+  - override /manager_env/terminations: tracking/base_adaptive_strict_ori_foot_xyz
+  - override /manager_env/rewards: tracking/base_5point_local_feet_acc
+
+use_manager_env: true
+
+exp_base: ${hydra:runtime.choices.exp}
+exp_var: test
+experiment_name: ${exp_base}_${exp_var}
+experiment_dir: ${base_dir}/${project_name}/${experiment_name}-${timestamp}
+
+num_envs: 4096
+project_name: TRL_X2Ultra_Track
+
+actor_prop_history_length: 10
+actor_actions_history_length: 10
+
+critic_prop_history_length: 10
+critic_actions_history_length: 10
+
+manager_env:
+  rewards:
+    feet_acc:
+      weight: -2.5e-6
+  config:
+    robot:
+      type: x2_ultra
+    terrain_type: trimesh
+  commands:
+    motion:
+      reward_point_body: ["torso_link", "left_wrist_yaw_link", "right_wrist_yaw_link"]
+      reward_point_body_offset: [[0.0, 0.0, 0.5], [0.0, -0.0, 0.0], [0.0, -0.0, 0.0]]
+      num_future_frames: 10
+      dt_future_ref_frames: 0.1
+      smpl_num_future_frames: 10
+      smpl_dt_future_ref_frames: 0.02
+      cat_upper_body_poses: true
+      cat_upper_body_poses_prob: 0.5
+
+      freeze_frame_aug: true
+      teleop_sample_prob_when_smpl: 0.5
+
+      motion_lib_cfg:
+        adaptive_sampling:
+          adp_samp_failure_rate_max_over_mean: 200
+        motion_file: null
+        smpl_motion_file: dummy
+        smpl_y_up: true
+        asset:
+          assetFileName: "x2_ultra.xml"
+
+algo:
+  config:
+    empty_cache_every_n_ppo_epoch: -1
+    num_steps_per_env: 24
+    use_clampped_std: true
+    std_clamp_min: 0.001
+    std_clamp_max: 0.5
+    max_grad_norm: 0.1
+    actor:
+      backbone:
+        reencode_smpl_g1_recon: true
+        encoders:
+          g1:
+            inputs: ["command_multi_future_nonflat", "motion_anchor_ori_b_mf_nonflat"]
+          teleop:
+            inputs:
+              [
+                "command_multi_future_lower_body",
+                "vr_3point_local_target",
+                "vr_3point_local_orn_target",
+                "motion_anchor_ori_b",
+              ]
+          smpl:
+            inputs:
+              [
+                "smpl_joints_multi_future_local_nonflat",
+                "smpl_root_ori_b_multi_future",
+                "joint_pos_multi_future_wrist_for_smpl",
+              ]
+        decoders:
+          g1_kin:
+            outputs: ["command_multi_future_nonflat", "motion_anchor_ori_b_mf_nonflat"]
+
+    critic:
+      backbone:
+        module_config_dict:
+          layer_config:
+            hidden_dims: [2048, 2048, 1024, 1024, 512, 512]

--- a/gear_sonic/config/exp/manager/universal_token/all_modes/sonic_x2_ultra_smoke.yaml
+++ b/gear_sonic/config/exp/manager/universal_token/all_modes/sonic_x2_ultra_smoke.yaml
@@ -1,16 +1,16 @@
 # @package _global_
-# SONIC X2 Ultra config — 3 encoders (G1/motion tracking, teleop, SMPL) for Agibot X2 Ultra.
-# Based on sonic_h2 but targeting the X2 Ultra robot (32 bodies, 31 DOF).
+# SONIC X2 Ultra smoke test — 2 encoders (motion tracking + teleop), no SMPL.
+# Minimal config for verifying the full pipeline end-to-end.
 
 defaults:
   - /algo: ppo_im_phc
   - /manager_env: base_env
   - /callbacks/read_eval
   - /callbacks/im_resample
-  - /aux_losses: universal_token/g1_recon_and_all_latent
+  - /aux_losses: universal_token/x2_recon_and_teleop_latent
   - override /trainer: trl_ppo_aux
-  - override /actor_critic: universal_token/all_mlp_v1
-  - override /manager_env/observations/tokenizer: unitoken_all_noz
+  - override /actor_critic: universal_token/x2_teleop_mlp_v1
+  - override /manager_env/observations/tokenizer: unitoken_x2_teleop_noz
   - override /manager_env/observations/policy: local_dir_hist
   - override /manager_env/observations/critic: privileged_mf_hist
   - override /manager_env/events: tracking/level0_4
@@ -20,12 +20,12 @@ defaults:
 use_manager_env: true
 
 exp_base: ${hydra:runtime.choices.exp}
-exp_var: test
+exp_var: smoke
 experiment_name: ${exp_base}_${exp_var}
 experiment_dir: ${base_dir}/${project_name}/${experiment_name}-${timestamp}
 
-num_envs: 4096
-project_name: TRL_X2Ultra_Track
+num_envs: 2
+project_name: TRL_X2Ultra_Smoke
 
 actor_prop_history_length: 10
 actor_actions_history_length: 10
@@ -50,25 +50,23 @@ manager_env:
       reward_point_body_offset: [[0.0, 0.0, 0.5], [0.0, -0.0, 0.0], [0.0, -0.0, 0.0]]
       num_future_frames: 10
       dt_future_ref_frames: 0.1
-      smpl_num_future_frames: 10
-      smpl_dt_future_ref_frames: 0.02
       cat_upper_body_poses: true
       cat_upper_body_poses_prob: 0.5
 
       freeze_frame_aug: true
-      teleop_sample_prob_when_smpl: 0.5
 
       motion_lib_cfg:
         adaptive_sampling:
           adp_samp_failure_rate_max_over_mean: 200
         motion_file: gear_sonic/data/motions/x2_ultra_soma_10.pkl
-        smpl_motion_file: dummy
+        smpl_motion_file: null
         smpl_y_up: true
         asset:
           assetFileName: "x2_ultra.xml"
 
 algo:
   config:
+    num_learning_iterations: 2000
     empty_cache_every_n_ppo_epoch: -1
     num_steps_per_env: 24
     use_clampped_std: true
@@ -77,7 +75,7 @@ algo:
     max_grad_norm: 0.1
     actor:
       backbone:
-        reencode_smpl_g1_recon: true
+        reencode_smpl_g1_recon: false
         encoders:
           g1:
             inputs: ["command_multi_future_nonflat", "motion_anchor_ori_b_mf_nonflat"]
@@ -88,13 +86,6 @@ algo:
                 "vr_3point_local_target",
                 "vr_3point_local_orn_target",
                 "motion_anchor_ori_b",
-              ]
-          smpl:
-            inputs:
-              [
-                "smpl_joints_multi_future_local_nonflat",
-                "smpl_root_ori_b_multi_future",
-                "joint_pos_multi_future_wrist_for_smpl",
               ]
         decoders:
           g1_kin:

--- a/gear_sonic/config/manager_env/observations/tokenizer/unitoken_x2_teleop_noz.yaml
+++ b/gear_sonic/config/manager_env/observations/tokenizer/unitoken_x2_teleop_noz.yaml
@@ -1,0 +1,29 @@
+# X2 Ultra tokenizer observations (2 encoders: motion tracking + teleop, no SMPL)
+
+defaults:
+  - ../terms/encoder_index@_here_
+  - ../terms/command_multi_future_nonflat@_here_
+  - ../terms/command_z_multi_future_nonflat@_here_
+  - ../terms/motion_anchor_ori_b_mf_nonflat@_here_
+  # teleop
+  - ../terms/command_multi_future_lower_body@_here_
+  - ../terms/vr_3point_local_target@_here_
+  - ../terms/vr_3point_local_orn_target@_here_
+  - ../terms/motion_anchor_ori_b@_here_
+  - ../terms/command_z@_here_
+
+_target_: gear_sonic.envs.manager_env.mdp.observations.TokenizerCfg
+enable_corruption: true
+concatenate_terms: false
+
+motion_anchor_ori_b_mf_nonflat:
+  noise:
+    _target_: isaaclab.utils.noise.AdditiveUniformNoiseCfg
+    n_min: -0.05
+    n_max: 0.05
+
+motion_anchor_ori_b:
+  noise:
+    _target_: isaaclab.utils.noise.AdditiveUniformNoiseCfg
+    n_min: -0.05
+    n_max: 0.05

--- a/gear_sonic/data/assets/robot_description/mjcf/x2_ultra.xml
+++ b/gear_sonic/data/assets/robot_description/mjcf/x2_ultra.xml
@@ -1,0 +1,435 @@
+<mujoco model="x2t2.5">
+  <compiler angle='radian' eulerseq="XYZ" meshdir="../urdf/x2_ultra/meshes"
+    autolimits="true" />
+
+  <statistic center="0 0 0.6" extent="1.3"/>
+
+  <option timestep="0.001" />
+
+  <visual>
+    <headlight diffuse="0.5 0.5 0.5" ambient="0.2 0.2 0.2" specular="0.9 0.9 0.9"/>
+    <global azimuth="200" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.3 0.52 0.63" rgb2="0.3 0.52 0.63" markrgb="1 1 1" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <default>
+      <default class="x2">
+          <site rgba="1 0 0 1" size="0.01" group="5"/>
+          <joint damping="0.0" armature="0.03" frictionloss="0.3"/>
+          <default class="visual">
+              <geom group="2" type="mesh" contype="0" conaffinity="0" density="0"/>
+          </default>
+          <default class="collision">
+              <geom group="3" type="mesh"/>
+              <default class="foot">
+                  <geom type="sphere" size="0.005"/>
+              </default>
+          </default>
+      </default>
+  </default>
+  <asset>
+    <mesh name="pelvis"  file="pelvis.STL"/>
+    <mesh name="imu_in_pelvis_link"  file="imu_in_pelvis_link.STL"/>
+    <mesh name="left_hip_pitch_link"  file="left_hip_pitch_link.STL"/>
+    <mesh name="left_hip_roll_link"  file="left_hip_roll_link.STL"/>
+    <mesh name="col_left_hip_roll_link"  file="left_hip_roll_link.STL" scale="1.0 0.9 1.0"/>
+    <mesh name="left_hip_yaw_link"  file="left_hip_yaw_link.STL"/>
+    <mesh name="left_knee_link"  file="left_knee_link.STL"/>
+    <mesh name="left_ankle_pitch_link"  file="left_ankle_pitch_link.STL"/>
+    <mesh name="left_ankle_roll_link"  file="left_ankle_roll_link.STL"/>
+    <mesh name="right_hip_pitch_link"  file="right_hip_pitch_link.STL"/>
+    <mesh name="right_hip_roll_link"  file="right_hip_roll_link.STL"/>
+    <mesh name="col_right_hip_roll_link"  file="right_hip_roll_link.STL" scale="1.0 0.9 1.0"/>
+    <mesh name="right_hip_yaw_link"  file="right_hip_yaw_link.STL"/>
+    <mesh name="right_knee_link"  file="right_knee_link.STL"/>
+    <mesh name="right_ankle_pitch_link"  file="right_ankle_pitch_link.STL"/>
+    <mesh name="right_ankle_roll_link"  file="right_ankle_roll_link.STL"/>
+    <mesh name="waist_yaw_link"  file="waist_yaw_link.STL"/>
+    <mesh name="waist_pitch_link"  file="waist_pitch_link.STL"/>
+    <mesh name="torso_link"  file="torso_plus_link.STL"/>
+    <mesh name="imu_in_torso_link"  file="imu_in_torso_link.STL"/>
+    <mesh name="left_shoulder_pitch_link"  file="left_shoulder_pitch_link.STL"/>
+    <mesh name="left_shoulder_roll_link"  file="left_shoulder_roll_link.STL"/>
+    <mesh name="left_shoulder_yaw_link"  file="left_shoulder_yaw_link.STL"/>
+    <mesh name="left_elbow_link"  file="left_elbow_link.STL"/>
+    <mesh name="left_wrist_yaw_link"  file="left_wrist_yaw_link.STL"/>
+    <mesh name="left_wrist_pitch_link"  file="left_wrist_pitch_link.STL"/>
+    <mesh name="left_wrist_roll_link"  file="left_wrist_roll_link.STL"/>
+    <mesh name="right_shoulder_pitch_link"  file="right_shoulder_pitch_link.STL"/>
+    <mesh name="right_shoulder_roll_link"  file="right_shoulder_roll_link.STL"/>
+    <mesh name="right_shoulder_yaw_link"  file="right_shoulder_yaw_link.STL"/>
+    <mesh name="right_elbow_link"  file="right_elbow_link.STL"/>
+    <mesh name="right_wrist_yaw_link"  file="right_wrist_yaw_link.STL"/>
+    <mesh name="right_wrist_pitch_link"  file="right_wrist_pitch_link.STL"/>
+    <mesh name="right_wrist_roll_link"  file="right_wrist_roll_link.STL"/>
+    <mesh name="head_yaw_link"  file="head_yaw_link.STL"/>
+    <mesh name="head_pitch_link"  file="head_pitch_link.STL"/>
+    <mesh name="imu_in_head_link"  file="imu_in_head_link.STL"/>
+    <!-- <mesh name="RGBD_in_head_link"  file="rgbd_in_head_link.STL"/>
+    <mesh name="RGB_binocular_link"  file="rgbd_binocular_link.STL"/>
+    <mesh name="RGB_rear_link"  file="rgbd_rear_link.STL"/>
+    <mesh name="RGB_Forward_link"  file="rgbd_forward_link.STL"/> -->
+  </asset>
+
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    <body name="pelvis" pos="0 0 0.68" euler="0 0 0" childclass="x2">
+      <light name="tracking" mode="trackcom" pos="0 0 2"/>
+      <freejoint name="floating_base_joint"/>
+      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="pelvis"/>
+      <geom class="collision"  type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="pelvis"/>
+      <geom class="visual" pos="0.0239465 -0.000228682 0.04171" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="imu_in_pelvis_link"/>
+      <site name="imu_0" pos="0.0239465 -0.000228682 0.04171" group="3"/>
+      <body name="left_hip_pitch_link" pos="0 0.07135 0">
+        <inertial pos="0.00791 0.064136 0.000116" quat="0.70601 0.705897 0.0403038 0.0404307" mass="1.39968" diaginertia="0.00807979 0.007409 0.00155421"/>
+        <joint name="left_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.704 2.556" actuatorfrcrange="-120 120"/>
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_hip_pitch_link"/>
+        <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" group="3" mesh="left_hip_pitch_link"/>
+        <body name="left_hip_roll_link" pos="-0.000575 0.0657 0">
+          <inertial pos="4.7e-05 0.000231 -0.093505" quat="0.703892 0.00104942 0.00203424 0.710303" mass="1.5848" diaginertia="0.0181021 0.0176713 0.00251468"/>
+          <joint name="left_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.235 2.906" actuatorfrcrange="-120 120"/>
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_hip_roll_link"/>
+          <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="col_left_hip_roll_link"/>
+          <body name="left_hip_yaw_link" pos="0.000575 0 -0.13685">
+            <inertial pos="-0.002375 0.003914 -0.144276" quat="0.647266 -0.0202222 0.00175224 0.761994" mass="2.01055" diaginertia="0.0526993 0.0519961 0.0023845"/>
+            <joint name="left_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-1.684 3.43" actuatorfrcrange="-120 120"/>
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_hip_yaw_link"/>
+            <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_hip_yaw_link"/>
+            <body name="left_knee_link" pos="-0.00766 0.000225 -0.1831">
+              <inertial pos="-0.002655 0.003681 -0.122697" quat="0.437302 -0.00633388 0.00636434 0.89927" mass="1.56821" diaginertia="0.031041 0.0309424 0.00193262"/>
+              <joint name="left_knee_joint" pos="0 0 0" axis="0 1 0" range="0 2.4073" actuatorfrcrange="-120 120"/>
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_knee_link"/>
+              <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_knee_link"/>
+              <body name="left_ankle_pitch_link" pos="-0.01 -0.000124911 -0.282">
+                <inertial pos="0.011691 -0.000181 0.003548" quat="0.72346 -0.0457688 0.0674454 0.685537" mass="0.747802" diaginertia="0.00117429 0.000984841 0.000709871"/>
+                <joint name="left_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.803 0.453" actuatorfrcrange="-36 36"/>
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_ankle_pitch_link"/>
+                <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="left_ankle_pitch_link"/>
+                <body name="left_ankle_roll_link" pos="-0.00175 0 0">
+                  <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949"/>
+                  <joint name="left_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.262 0.262" actuatorfrcrange="-24 24"/>
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="left_ankle_roll_link"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.05 0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.065 0.025 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.05 -0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.065 -0.025 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.11 0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.11 -0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.02 -0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="-0.02 0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.07 -0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.07 0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.139 0 -0.066" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3"  size="0.005" pos="0.128 0 -0.02" rgba="1 0.5 0 1"/>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="right_hip_pitch_link" pos="0 -0.07135 0">
+        <inertial pos="0.007909 -0.064114 0.000131" quat="0.705894 0.706007 -0.0404833 -0.0403565" mass="1.40023" diaginertia="0.00808102 0.007409 0.00155498"/>
+        <joint name="right_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.704 2.556" actuatorfrcrange="-120 120"/>
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_hip_pitch_link"/>
+        <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="right_hip_pitch_link"/>
+        <body name="right_hip_roll_link" pos="0 -0.0657 0">
+          <inertial pos="-0.000586 -0.000228 -0.093568" quat="0.710476 -8.90189e-06 -0.00101098 0.703721" mass="1.58508" diaginertia="0.0181161 0.017694 0.00251594"/>
+          <joint name="right_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.906 0.235" actuatorfrcrange="-120 120"/>
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_hip_roll_link"/>
+          <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="col_right_hip_roll_link"/>
+          <body name="right_hip_yaw_link" pos="0 0 -0.13685">
+            <inertial pos="-0.002444 -0.003935 -0.144335" quat="0.762367 0.00171388 -0.0204012 0.646821" mass="2.00262" diaginertia="0.0525579 0.0518558 0.0023773"/>
+            <joint name="right_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-3.43 1.684" actuatorfrcrange="-120 120"/>
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_hip_yaw_link"/>
+            <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_hip_yaw_link"/>
+            <body name="right_knee_link" pos="-0.00766 -0.000225 -0.1831">
+              <inertial pos="-0.002699 -0.003794 -0.122288" quat="0.90334 0.0065752 -0.00663139 0.428824" mass="1.56588" diaginertia="0.0308703 0.0307718 0.00192491"/>
+              <joint name="right_knee_joint" pos="0 0 0" axis="0 1 0" range="0 2.4073" actuatorfrcrange="-120 120"/>
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_knee_link"/>
+              <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_knee_link"/>
+              <body name="right_ankle_pitch_link" pos="-0.01 0.000124911 -0.282">
+                <inertial pos="0.011665 0.000937 0.00394" quat="0.7183 0.0624712 -0.034146 0.692081" mass="0.749566" diaginertia="0.00122381 0.00103716 0.000713034"/>
+                <joint name="right_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.803 0.453" actuatorfrcrange="-36 36"/>
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_ankle_pitch_link"/>
+                <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="right_ankle_pitch_link"/>
+                <body name="right_ankle_roll_link" pos="-0.00175 0 0">
+                  <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949"/>
+                  <joint name="right_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.2625 0.2625" actuatorfrcrange="-24 24"/>
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="right_ankle_roll_link"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.05 0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.065 0.025 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.05 -0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.065 -0.025 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.11 0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.11 -0.05 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.02 -0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="-0.02 0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.07 -0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.07 0.06 -0.068" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.139 0 -0.066" rgba="1 0.5 0 1"/>
+                  <geom class="collision" type="sphere" group="3" size="0.005" pos="0.128 0 -0.02" rgba="1 0.5 0 1"/>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="waist_yaw_link" pos="0 0 0.06706">
+        <inertial pos="-0.001359 4.7e-05 0.041703" quat="0.99876 0.000921559 0.0477625 0.0140034" mass="1.66854" diaginertia="0.00503206 0.00499998 0.00283196"/>
+        <joint name="waist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-3.43 2.382" actuatorfrcrange="-120 120"/>
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="waist_yaw_link"/>
+        <!-- <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="waist_yaw_link"/> -->
+        <body name="waist_pitch_link" pos="0 0 0.0880106">
+          <inertial pos="0.008967 -1e-06 0" quat="0.5 0.5 -0.5 0.5" mass="0.392413" diaginertia="0.00023 0.000133 0.000133"/>
+          <joint name="waist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.314 0.314" actuatorfrcrange="-48 48"/>
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="waist_pitch_link"/>
+          <!-- <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="waist_pitch_link"/> -->
+          <body name="torso_link">
+          <inertial pos="-0.000188 0.000605 0.191827" quat="0.999959 0.00110321 0.0081892 0.00362262" mass="10.1441" diaginertia="0.479863 0.455999 0.0666413"/>
+            <joint name="waist_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.488 0.488" actuatorfrcrange="-48 48"/>
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="torso_link"/>
+            <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="torso_link"/>
+            <site name="imu_1" pos="-0.0248787 0.00198528 0.105938" group="3"/>
+            <geom class="visual" pos="-0.0248787 0.00198528 0.105938" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.647059 0.619608 0.588235 1" mesh="imu_in_torso_link"/>
+            <body name="left_shoulder_pitch_link" pos="0.00329907 0.143032 0.241648" quat="0.994522 0.104528 0 0">
+              <inertial pos="0.003007 0.050014 6.2e-05" quat="0.707145 0.706403 0.027325 0.0139105" mass="0.885896" diaginertia="0.00303104 0.00292896 0.000676999"/>
+              <joint name="left_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.08 2.04" actuatorfrcrange="-36 36"/>
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_shoulder_pitch_link"/>
+              <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="left_shoulder_pitch_link"/>
+              <body name="left_shoulder_roll_link" pos="-0.000499991 0.0495 0">
+                <inertial pos="0.000621 -0.000183 -0.078842" quat="0.706401 0.00587444 0.00386922 0.707777" mass="0.706556" diaginertia="0.00549904 0.00540092 0.000539037"/>
+                <joint name="left_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.061 2.993" actuatorfrcrange="-36 36"/>
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_shoulder_roll_link"/>
+                <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_shoulder_roll_link"/>
+                <body name="left_shoulder_yaw_link" pos="0.00122424 0 -0.121195" quat="0.999996 0 -0.00298782 0">
+                  <inertial pos="0.010005 0.000179 -0.069477" quat="0.996444 0.00144278 0.0782236 0.0312643" mass="0.704662" diaginertia="0.00438693 0.00436694 0.00044713"/>
+                  <joint name="left_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24"/>
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_shoulder_yaw_link"/>
+                  <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_shoulder_yaw_link"/>
+                  <body name="left_elbow_link" pos="0.014 0.000199986 -0.08295" quat="0.999996 0 0.00298782 0">
+                    <inertial pos="-0.013174 0.003788 -0.080203" quat="0.970867 0.0083727 -0.0764035 -0.226955" mass="0.688008" diaginertia="0.0054008 0.00531735 0.000446844"/>
+                    <joint name="left_elbow_joint" pos="0 0 0" axis="0 1 0" range="-2.3556 0" actuatorfrcrange="-24 24"/>
+                    <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_elbow_link"/>
+                    <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_elbow_link"/>
+                    <body name="left_wrist_yaw_link" pos="-0.0132797 -9.75488e-05 -0.120576">
+                      <inertial pos="7.6e-05 0.007263 -0.030679" quat="0.992384 -0.122507 -0.00213896 -0.0126728" mass="0.360708" diaginertia="0.000612057 0.000527003 0.00018794"/>
+                      <joint name="left_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24"/>
+                      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_wrist_yaw_link"/>
+                      <!-- <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="left_wrist_yaw_link"/> -->
+                      <body name="left_wrist_pitch_link" pos="0.000490001 0 -0.0819985" quat="0.999996 0 -0.00298783 0">
+                        <inertial pos="0.011479 0.002282 0.001703" quat="0.258763 0.693211 0.202262 0.641553" mass="0.292062" diaginertia="0.000178433 0.000138482 9.10855e-05"/>
+                        <joint name="left_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.558 0.558" actuatorfrcrange="-4.8 4.8"/>
+                        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.3 0.3 0.3 1" mesh="left_wrist_pitch_link"/>
+                        <geom class="collision" type="mesh" rgba="0.3 0.3 0.3 1" mesh="left_wrist_pitch_link"/>
+                        <body name="left_wrist_roll_link">
+                          <inertial pos="0.002935 -0.001499 -0.083026" quat="0.606338 0.022665 0.0055862 0.794865" mass="0.30304" diaginertia="0.00278114 0.00266331 0.000205545"/>
+                          <joint name="left_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-1.571 0.724" actuatorfrcrange="-4.8 4.8"/>
+                          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.898039 0.917647 0.929412 1" mesh="left_wrist_roll_link"/>
+                          <geom class="collision" type="mesh" rgba="0.898039 0.917647 0.929412 1" mesh="left_wrist_roll_link"/>
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+            <body name="right_shoulder_pitch_link" pos="0.00330094 -0.143031 0.241648" quat="0.994522 -0.10453 0 0">
+              <inertial pos="0.002721 -0.050304 3.4e-05" quat="0.706743 0.706967 -0.0144448 -0.0224265" mass="0.885544" diaginertia="0.00303743 0.00294899 0.00067458"/>
+              <joint name="right_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.08 2.04" actuatorfrcrange="-36 36"/>
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_shoulder_pitch_link"/>
+              <geom class="collision" type="mesh" rgba="0.298039 0.298039 0.298039 1" mesh="right_shoulder_pitch_link"/>
+              <body name="right_shoulder_roll_link" pos="-0.0005 -0.0495 0" quat="1 0 7.70015e-05 0">
+                <inertial pos="0.000598 0.000185 -0.079928" quat="0.707532 0.00175816 0.00375761 0.706669" mass="0.696963" diaginertia="0.00548904 0.0054003 0.000529664"/>
+                <joint name="right_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.993 0.061" actuatorfrcrange="-36 36"/>
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_shoulder_roll_link"/>
+                <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_shoulder_roll_link"/>
+                <body name="right_shoulder_yaw_link" pos="0.0005 0 -0.1212">
+                  <inertial pos="0.010082 -0.000178 -0.069484" quat="0.996531 -0.00117604 0.0784297 -0.0277917" mass="0.704661" diaginertia="0.00438849 0.00436595 0.000445562"/>
+                  <joint name="right_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24"/>
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_shoulder_yaw_link"/>
+                  <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_shoulder_yaw_link"/>
+                  <body name="right_elbow_link" pos="0.014 -0.0002 -0.08295">
+                    <inertial pos="-0.013517 -0.003463 -0.080438" quat="0.973224 -0.00938144 -0.0782816 0.215913" mass="0.687932" diaginertia="0.00542019 0.00534355 0.000444255"/>
+                    <joint name="right_elbow_joint" pos="0 0 0" axis="0 1 0" range="-2.3556 0" actuatorfrcrange="-24 24"/>
+                    <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_elbow_link"/>
+                    <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_elbow_link"/>
+                    <body name="right_wrist_yaw_link" pos="-0.014 9.75261e-05 -0.120694" quat="1 0 0 1.63671e-05">
+                      <inertial pos="0.000153 -0.006979 -0.032069" quat="0.994972 0.0996496 -0.000602255 0.0100452" mass="0.372787" diaginertia="0.00069604 0.000598539 0.000202421"/>
+                      <joint name="right_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24"/>
+                      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_wrist_yaw_link"/>
+                      <!-- <geom class="collision" type="mesh" rgba="1 1 1 1" mesh="right_wrist_yaw_link"/> -->
+                      <body name="right_wrist_pitch_link" pos="0 0 -0.0818" quat="1 0 0 -1.63671e-05">
+                        <inertial pos="0.012092 -0.002544 0.001781" quat="-0.292763 0.682227 -0.235996 0.627027" mass="0.279175" diaginertia="0.000171965 0.00013308 8.19541e-05"/>
+                        <joint name="right_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.558 0.558" actuatorfrcrange="-4.8 4.8"/>
+                        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.3 0.3 0.3 1" mesh="right_wrist_pitch_link"/>
+                        <geom class="collision" type="mesh" rgba="0.3 0.3 0.3 1" mesh="right_wrist_pitch_link"/>
+                        <body name="right_wrist_roll_link">
+                          <inertial pos="0.003056 0.00138 -0.082799" quat="0.794575 0.00682121 0.0232843 0.606681" mass="0.303847" diaginertia="0.002781 0.00266288 0.000206121"/>
+                          <joint name="right_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.724 1.571" actuatorfrcrange="-4.8 4.8"/>
+                          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.898039 0.917647 0.929412 1" mesh="right_wrist_roll_link"/>
+                          <geom class="collision" type="mesh" rgba="0.898039 0.917647 0.929412 1" mesh="right_wrist_roll_link"/>
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+            <body name="head_yaw_link" pos="0.00834773 0 0.309397">
+              <inertial pos="-0.003139 0.001399 0.051838" quat="0.999924 -0.00911422 0.00384341 0.00741605" mass="0.720047" diaginertia="0.0038613 0.00323157 0.00110213"/>
+              <joint name="head_yaw_joint" pos="0 0 0" axis="0 0 1" range="-0.366 0.366" actuatorfrcrange="-2.6 2.6"/>
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.866667 0.866667 0.890196 1" mesh="head_yaw_link"/>
+              <!-- <geom class="collision" type="mesh" rgba="0.866667 0.866667 0.890196 1" mesh="head_yaw_link"/> -->
+              <body name="head_pitch_link" pos="0 0 0.0889">
+                <inertial pos="0.003033 -6e-05 0.004395" quat="0.695573 -0.162421 -0.145198 0.684628" mass="0.999287" diaginertia="0.0035988 0.00298179 0.00259841"/>
+                <joint name="head_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.3838 0.3838" actuatorfrcrange="-0.6 0.6"/>
+                <geom class="collision" size="0.074 0.05" pos="0 0 0.015" quat="0.499898 0.5 0.5 -0.500102" type="cylinder" rgba="0.498039 0.498039 0.498039 1"/>
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="head_pitch_link"/>
+                <!-- <geom class="collision" type="mesh" rgba="0.2 0.2 0.2 1" mesh="head_pitch_link"/> -->
+                <site name="imu_2" pos="0.0259999 -8.25389e-05 0.0176" group="3"/>
+                <geom class="visual" pos="0.0259999 -8.25389e-05 0.0176" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.647059 0.619608 0.588235 1" mesh="imu_in_head_link"/>
+                <!-- <geom class="visual" pos="0.0576096 -0.0111832 -0.0483697" quat="0.298835 0.640857 0.640857 0.298835" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.647059 0.619608 0.588235 1" mesh="RGBD_in_head_link"/>
+                <geom class="visual" pos="0.0678044 -0.0302154 0.0500001" quat="0.500782 0.500805 0.499193 0.499217" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.266667 0.266667 0.266667 1" mesh="RGB_binocular_link"/> -->
+                <!-- <geom class="visual" pos="-0.0833996 0.000264949 0" quat="0.499205 0.499205 -0.500794 -0.500794" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.866667 0.866667 0.890196 1" mesh="RGB_rear_link"/>
+                <geom class="visual" pos="0.0684 -0.000217129 0.05" quat="0.500794 0.500794 0.499205 0.499205" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.501961 0.501961 0.501961 1" mesh="RGB_Forward_link"/> -->
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor class="x2" name="motor_left_hip_pitch_joint" joint="left_hip_pitch_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_left_hip_roll_joint" joint="left_hip_roll_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_left_hip_yaw_joint" joint="left_hip_yaw_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_left_knee_joint" joint="left_knee_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_left_ankle_pitch_joint" joint="left_ankle_pitch_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_left_ankle_roll_joint" joint="left_ankle_roll_joint" ctrlrange="-24 24"/>
+
+    <motor class="x2" name="motor_right_hip_pitch_joint" joint="right_hip_pitch_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_right_hip_roll_joint" joint="right_hip_roll_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_right_hip_yaw_joint" joint="right_hip_yaw_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_right_knee_joint" joint="right_knee_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_right_ankle_pitch_joint" joint="right_ankle_pitch_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_right_ankle_roll_joint" joint="right_ankle_roll_joint" ctrlrange="-24 24"/>
+
+    <motor class="x2" name="motor_waist_yaw_joint" joint="waist_yaw_joint" ctrlrange="-118 118"/>
+    <motor class="x2" name="motor_waist_pitch_joint" joint="waist_pitch_joint" ctrlrange="-48 48"/>
+    <motor class="x2" name="motor_waist_roll_joint" joint="waist_roll_joint" ctrlrange="-48 48"/>
+
+    <motor class="x2" name="motor_head_yaw_joint" joint="head_yaw_joint" ctrlrange="-2.6 2.6"/>
+    <motor class="x2" name="motor_head_pitch_joint" joint="head_pitch_joint" ctrlrange="-0.6 0.6"/>
+
+    <motor class="x2" name="motor_left_shoulder_pitch_joint" joint="left_shoulder_pitch_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_left_shoulder_roll_joint" joint="left_shoulder_roll_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_left_shoulder_yaw_joint" joint="left_shoulder_yaw_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_left_elbow_joint" joint="left_elbow_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_left_wrist_yaw_joint" joint="left_wrist_yaw_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_left_wrist_pitch_joint" joint="left_wrist_pitch_joint" ctrlrange="-2.2 2.2"/>
+    <motor class="x2" name="motor_left_wrist_roll_joint" joint="left_wrist_roll_joint" ctrlrange="-2.2 2.2"/>
+
+    <motor class="x2" name="motor_right_shoulder_pitch_joint" joint="right_shoulder_pitch_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_right_shoulder_roll_joint" joint="right_shoulder_roll_joint" ctrlrange="-36 36"/>
+    <motor class="x2" name="motor_right_shoulder_yaw_joint" joint="right_shoulder_yaw_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_right_elbow_joint" joint="right_elbow_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_right_wrist_yaw_joint" joint="right_wrist_yaw_joint" ctrlrange="-24 24"/>
+    <motor class="x2" name="motor_right_wrist_pitch_joint" joint="right_wrist_pitch_joint" ctrlrange="-2.2 2.2"/>
+    <motor class="x2" name="motor_right_wrist_roll_joint" joint="right_wrist_roll_joint" ctrlrange="-2.2 2.2"/>
+  </actuator>
+  <sensor>
+    <!-- <gyro name="imu0-gyro" site="imu_0" cutoff="7.85"/>
+    <accelerometer name="imu0-acc" site="imu_0" cutoff="157"/>
+    <framequat name="imu0-quat" objtype="site" objname="imu_0"/>
+
+    <gyro name="imu1-gyro" site="imu_1" cutoff="7.85"/>
+    <accelerometer name="imu1-acc" site="imu_1" cutoff="157"/>
+    <framequat name="imu1-quat" objtype="site" objname="imu_1"/> -->
+
+    <framequat name="body-orientation" objtype="site" objname="imu_0" noise="0"/>
+    <gyro name="body-angular-velocity" site="imu_0" noise="0.001"/>
+    <framepos name="body-linear-pos" objtype="site" objname="imu_0"/>
+    <velocimeter name="body-linear-vel" site="imu_0"/>
+    <accelerometer name="body-linear-acceleration" site="imu_0" noise="0.001"/>
+    
+    <jointpos name = 'jointpos_left_hip_pitch_joint' joint = 'left_hip_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_hip_roll_joint' joint = 'left_hip_roll_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_hip_yaw_joint' joint = 'left_hip_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_knee_joint' joint = 'left_knee_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_ankle_pitch_joint' joint = 'left_ankle_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_ankle_roll_joint' joint = 'left_ankle_roll_joint' noise = "0" />
+
+    <jointpos name = 'jointpos_right_hip_pitch_joint' joint = 'right_hip_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_hip_roll_joint' joint = 'right_hip_roll_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_hip_yaw_joint' joint = 'right_hip_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_knee_joint' joint = 'right_knee_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_ankle_pitch_joint' joint = 'right_ankle_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_ankle_roll_joint' joint = 'right_ankle_roll_joint' noise = "0" />
+
+    <jointpos name = 'jointpos_waist_yaw_joint' joint = 'waist_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_waist_pitch_joint' joint = 'waist_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_waist_roll_joint' joint = 'waist_roll_joint' noise = "0" />
+
+    <jointpos name = 'jointpos_head_yaw_joint' joint = 'head_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_head_pitch_joint' joint = 'head_pitch_joint' noise = "0" />
+
+    <jointpos name = 'jointpos_left_shoulder_pitch_joint' joint = 'left_shoulder_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_shoulder_roll_joint' joint = 'left_shoulder_roll_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_shoulder_yaw_joint' joint = 'left_shoulder_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_elbow_joint' joint = 'left_elbow_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_wrist_yaw_joint' joint = 'left_wrist_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_wrist_pitch_joint' joint = 'left_wrist_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_left_wrist_roll_joint' joint = 'left_wrist_roll_joint' noise = "0" />
+
+    <jointpos name = 'jointpos_right_shoulder_pitch_joint' joint = 'right_shoulder_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_shoulder_roll_joint' joint = 'right_shoulder_roll_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_shoulder_yaw_joint' joint = 'right_shoulder_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_elbow_joint' joint = 'right_elbow_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_wrist_yaw_joint' joint = 'right_wrist_yaw_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_wrist_pitch_joint' joint = 'right_wrist_pitch_joint' noise = "0" />
+    <jointpos name = 'jointpos_right_wrist_roll_joint' joint = 'right_wrist_roll_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_left_hip_pitch_joint' joint = 'left_hip_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_hip_roll_joint' joint = 'left_hip_roll_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_hip_yaw_joint' joint = 'left_hip_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_knee_joint' joint = 'left_knee_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_ankle_pitch_joint' joint = 'left_ankle_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_ankle_roll_joint' joint = 'left_ankle_roll_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_right_hip_pitch_joint' joint = 'right_hip_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_hip_roll_joint' joint = 'right_hip_roll_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_hip_yaw_joint' joint = 'right_hip_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_knee_joint' joint = 'right_knee_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_ankle_pitch_joint' joint = 'right_ankle_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_ankle_roll_joint' joint = 'right_ankle_roll_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_waist_yaw_joint' joint = 'waist_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_waist_pitch_joint' joint = 'waist_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_waist_roll_joint' joint = 'waist_roll_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_head_yaw_joint' joint = 'head_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_head_pitch_joint' joint = 'head_pitch_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_left_shoulder_pitch_joint' joint = 'left_shoulder_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_shoulder_roll_joint' joint = 'left_shoulder_roll_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_shoulder_yaw_joint' joint = 'left_shoulder_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_elbow_joint' joint = 'left_elbow_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_wrist_yaw_joint' joint = 'left_wrist_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_wrist_pitch_joint' joint = 'left_wrist_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_left_wrist_roll_joint' joint = 'left_wrist_roll_joint' noise = "0" />
+
+    <jointvel name = 'jointvel_right_shoulder_pitch_joint' joint = 'right_shoulder_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_shoulder_roll_joint' joint = 'right_shoulder_roll_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_shoulder_yaw_joint' joint = 'right_shoulder_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_elbow_joint' joint = 'right_elbow_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_wrist_yaw_joint' joint = 'right_wrist_yaw_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_wrist_pitch_joint' joint = 'right_wrist_pitch_joint' noise = "0" />
+    <jointvel name = 'jointvel_right_wrist_roll_joint' joint = 'right_wrist_roll_joint' noise = "0" />
+
+  </sensor>
+</mujoco>

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/head_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/head_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:765cd7690f861bba7bae520e7ba7be04234bc9ef423fa6679ef9fbf17de646ca
+size 3466234

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/head_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/head_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65fa0bb64c61e57de2f263f800500870094fec58b715f92eb89fa35c77acb578
+size 481484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_head_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_head_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fe3dd993bec739596e58dcf2570a2c69c271692b13562491bfe412670d33f36
+size 2454684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_pelvis_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_pelvis_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:026069215f433d76235234a6d5b408db90f29570048c280d3ba5c144905ca947
+size 2454684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_torso_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/imu_in_torso_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58ca0996b0334f692c5357db55c66ace3cc7f315d1519867cccaf8e21efeaa0f
+size 2454684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_ankle_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_ankle_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74b49844186ddf6480a6688e1b8e86ec403c5ab954ca364516c4ebb10ea62e29
+size 965884

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_ankle_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_ankle_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47a3b755fc7c3bd4c61f7b26fd75bff2046601d64491709f6f5f62334ee310f8
+size 3574584

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_elbow_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_elbow_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e82bfa1184c8b769895cdd433b48a5df0e064ffce62646fee3e6f66e4cb50dd5
+size 1367484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:579f9223f575779b697379655052ce6c9864fe976b11652844fd4a6d31be370b
+size 2171684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02ae153f4e2e1bac9916a332b1188efe42f8aabf67de923902469422978d097c
+size 4169384

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_hip_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0734abbe510959d2dfa0616d0fa8f7d713cc572204bdf9413cddde8445b43a4f
+size 4306384

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_knee_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_knee_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bbe9bfcb7a26948748f5875f6aa79b6984f12f20eb1f76b8129de7d0ed52fc2
+size 4795984

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:491259031bc2894f7bc2eeea47dcff57158ddba28261ca2ec28eede34f83042f
+size 900484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:656348cd02ae0dafd683aabe443c23a7a5af807c28518519150fca3959380c26
+size 2411584

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_shoulder_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:980ce837e785a49df41cb470351ae6124329b309fb0f05da03b992f443687fef
+size 1891984

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_fist_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_fist_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0f74bf9a1a47949926454464772fff8ac38c995e432458ce6e9d8d8834df7ce
+size 4398484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_hand_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_hand_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ed92feadf3d48fb39aa8bb3c057a9c2dc1cc648f45029f7ef75ed814faa0cd1
+size 3052184

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:732f2881aa05e9cef01e451193d7094ccf74cf730ec18864711b8bf8c77e8a43
+size 2256634

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf18915b8874853de1086b90ffa2680582e22f84ec25820bef48d8d25290678
+size 1910184

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/left_wrist_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fb206c94806f813fe26dcef7238dc458d049cd86767d11f52542ea11e09844e
+size 1840184

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/lidar_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/lidar_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39a9ad6ae4a78cbe3ea39fb74576074d57305f8ababb1197cd18c18e23c5b296
+size 84

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/pelvis.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/pelvis.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a068b0024f2e2db4f743369184d868db5273ce37c26bdc8f44344dabb36a3595
+size 2889984

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgb_head_center_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgb_head_center_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:592597458fd03133b683e13878924fa91ff8a1e84d9cc94fc38c67b34199211e
+size 1146834

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgb_head_rear_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgb_head_rear_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe6f31ce89484648c8ac4c8358eeabe417aba45891841db762055e06f72cdd83
+size 673434

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgbd_head_front_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/rgbd_head_front_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91dd61db6d4db074502e9c50d9cd1b23f33fdbd9786a08e18328ec3ffca7fa78
+size 24084

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_ankle_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_ankle_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a31d4adb16a1fb7e4bb2de1f8ffa962e9d8cc74337ff8a56f8c7fd97d8c9e37
+size 965884

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_ankle_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_ankle_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f5d26addecdbd6fff8bef111a9f50d1c220421096a97e9f217fa7d00c8582e3
+size 3574584

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_elbow_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_elbow_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07f9fac6dcd14bd349e803a266153639543d0f68c5a6d6652d5b0c093de57ac8
+size 1403184

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d9a7be650e73899e312c7b3e34bf65c6064bfc94e85422eb3e513c011970379
+size 2164084

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f34d70535a16aa02280dde697fdff4ad9901a57e9a1ff21f47ffb374e319b3e4
+size 4187784

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_hip_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cde24c04b2262b77efb52a887d2991234bbef12b704026ed46b6c661b0ee0fe
+size 4296684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_knee_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_knee_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9839e23940315f91d41f8b91e28dc979901678560ea178d153867d7dac0680e
+size 4786984

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0931e176158a408171d13def0b3779f366fcf658ab9066fb6cc65061aa8bfa47
+size 904084

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:948f9625cc09aded578f2f29a33d4e1fedbe8db2f7cd89e5c9d45c1028a8ad18
+size 2433284

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_shoulder_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e144ca3d076753122b0b27dc2d81d06fdb28294fd898f7b82fd71552bb9988f3
+size 1411684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_fist_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_fist_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e9d81fe0fe48701eb91de4ac4e5295f67e4423f0bfe613224717cb08dd77d7
+size 4399684

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_hand_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_hand_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b053e6b4185fac00803f7176d396b5acc0010863e8a71e5e05f97aaa1feb589
+size 2933384

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35ec085c532cbb5e8e761625bb3efb9b121089c16fe2519933038925984ad24a
+size 2255084

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_roll_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_roll_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86ff42a11fd2bb4c00f8bd652ee030042cd1ed3e35651c5e9d91dec44f2f83e6
+size 1800784

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/right_wrist_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3be4f79da120a73d8ecc9d1cd6d41d667024a9f8a1664765ecc424a01bcd1a01
+size 1848084

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/stereo_head_front_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/stereo_head_front_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a6a9374416161bef4064ae891e06e7d2cef540ef328faf6de3db90d1ffbe2ad
+size 1742584

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/torso_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/torso_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:121e0976e6cca39850fd5eb17e1107d576105c116b5dbaaefe085cff547b76af
+size 8431384

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/torso_plus_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/torso_plus_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af1c9f2e57bb9f3e54e895ff309d8990ed54c0a6a77c5617d319304267cec0d0
+size 8530384

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/waist_pitch_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/waist_pitch_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b36f476a27cd6bc5aa83870ad126183292ce40e73de9fd3c556b609f5a5a2e
+size 963484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/waist_yaw_link.STL
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/meshes/waist_yaw_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb7c9813f358fb563b812c386cad49db12c36b569b671976a84fb6f556e594f2
+size 1395484

--- a/gear_sonic/data/assets/robot_description/urdf/x2_ultra/x2_ultra.urdf
+++ b/gear_sonic/data/assets/robot_description/urdf/x2_ultra/x2_ultra.urdf
@@ -1,0 +1,1049 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot name="x2t2.5">
+  <mujoco>
+    <compiler meshdir="meshes" discardvisual="false" />
+  </mujoco>
+  <link name="pelvis">
+    <inertial>
+      <origin xyz="-0.001209 -2.3e-05 -0.002011" rpy="0 0 0" />
+      <mass value="3.523487" />
+      <inertia ixx="0.0126" ixy="0.0" ixz="0.000163" iyy="0.007924" iyz="-5e-06" izz="0.012417" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/pelvis.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/pelvis.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <link name="imu_in_pelvis_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/imu_in_pelvis_link.STL" />
+      </geometry>
+    </visual>
+  </link>
+  <joint name="imu_in_pelvis_joint" type="fixed">
+    <origin xyz="0.0239464627920677 -0.00022868187247424 0.0417100000000296" rpy="0 0 0" />
+    <parent link="pelvis" />
+    <child link="imu_in_pelvis_link" />
+    <axis xyz="0 0 0" />
+  </joint>
+  <link name="left_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.00791 0.064136 0.000116" rpy="0 0 0" />
+      <mass value="1.399682" />
+      <inertia ixx="0.007995" ixy="0.000739" ixz="0.0" iyy="0.001639" iyz="1e-06" izz="0.007409" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_pitch_joint" type="revolute">
+    <origin xyz="0 0.0713499997541465 0" rpy="0 0 0" />
+    <parent link="pelvis" />
+    <child link="left_hip_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.704" upper="2.556" effort="120" velocity="11.936" />
+  </joint>
+  <link name="left_hip_roll_link">
+    <inertial>
+      <origin xyz="4.7e-05 0.000231 -0.093505" rpy="0 0 0" />
+      <mass value="1.584804" />
+      <inertia ixx="0.017671" ixy="-4e-06" ixz="-6.6e-05" iyy="0.018102" iyz="-2.2e-05" izz="0.002515" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL" scale="1.0 0.9 1.0" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_roll_joint" type="revolute">
+    <origin xyz="-0.000574999999960968 0.0657000000000312 0" rpy="0 0 0" />
+    <parent link="left_hip_pitch_link" />
+    <child link="left_hip_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.235" upper="2.906" effort="120" velocity="11.936" />
+  </joint>
+  <link name="left_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.002375 0.003914 -0.144276" rpy="0 0 0" />
+      <mass value="2.010551" />
+      <inertia ixx="0.051974" ixy="-7.1e-05" ixz="0.001419" iyy="0.052639" iyz="-0.001453" izz="0.002467" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_yaw_joint" type="revolute">
+    <origin xyz="0.000574999999972778 0 -0.136850000000045" rpy="0 0 0" />
+    <parent link="left_hip_roll_link" />
+    <child link="left_hip_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-1.684" upper="3.43" effort="120" velocity="11.936" />
+  </joint>
+  <link name="left_knee_link">
+    <inertial>
+      <origin xyz="-0.002655 0.003681 -0.122697" rpy="0 0 0" />
+      <mass value="1.568215" />
+      <inertia ixx="0.030979" ixy="-4.5e-05" ixz="0.00017" iyy="0.030995" iyz="-0.000494" izz="0.001942" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_knee_joint" type="revolute">
+    <origin xyz="-0.00765999999995284 0.000225000000070329 -0.18309999999998" rpy="0 0 0" />
+    <parent link="left_hip_yaw_link" />
+    <child link="left_knee_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="0" upper="2.4073" effort="120" velocity="11.936" />
+  </joint>
+  <link name="left_ankle_pitch_link">
+    <inertial>
+      <origin xyz="0.011691 -0.000181 0.003548" rpy="0 0 0" />
+      <mass value="0.747802" />
+      <inertia ixx="0.000985" ixy="8e-06" ixz="-1.1e-05" iyy="0.001162" iyz="-7.3e-05" izz="0.000722" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_pitch_joint" type="revolute">
+    <origin xyz="-0.0100000000000136 -0.000124910735236235 -0.282000000000081" rpy="0 0 0" />
+    <parent link="left_knee_link" />
+    <child link="left_ankle_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.803" upper="0.453" effort="36" velocity="13.087" />
+  </joint>
+  <link name="left_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.035428 2.5e-05 -0.049572" rpy="0 0 0" />
+      <mass value="1.016166" />
+      <inertia ixx="0.0037" ixy="2e-06" ixz="-0.001872" iyy="0.007937" iyz="-1e-06" izz="0.005766" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_ankle_roll_link.STL" />
+      </geometry>
+      <material name="yellow">
+        <color rgba="1.0 0.5 0.0 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_ankle_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_roll_joint" type="revolute">
+    <origin xyz="-0.00174999998947351 0 0" rpy="0 0 0" />
+    <parent link="left_ankle_pitch_link" />
+    <child link="left_ankle_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.262" upper="0.262" effort="24" velocity="15.077" />
+  </joint>
+  <link name="right_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.007909 -0.064114 0.000131" rpy="0 0 0" />
+      <mass value="1.400227" />
+      <inertia ixx="0.007996" ixy="-0.00074" ixz="0.0" iyy="0.00164" iyz="-1e-06" izz="0.007409" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_pitch_joint" type="revolute">
+    <origin xyz="0 -0.0713499997541464 0" rpy="0 0 0" />
+    <parent link="pelvis" />
+    <child link="right_hip_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.704" upper="2.556" effort="120" velocity="11.936" />
+  </joint>
+  <link name="right_hip_roll_link">
+    <inertial>
+      <origin xyz="-0.000586 -0.000228 -0.093568" rpy="0 0 0" />
+      <mass value="1.585084" />
+      <inertia ixx="0.017694" ixy="4e-06" ixz="2.2e-05" iyy="0.018116" iyz="2.2e-05" izz="0.002516" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL" scale="1.0 0.9 1.0" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_roll_joint" type="revolute">
+    <origin xyz="0 -0.0657000004916197 0" rpy="0 0 0" />
+    <parent link="right_hip_pitch_link" />
+    <child link="right_hip_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.906" upper="0.235" effort="120" velocity="11.936" />
+  </joint>
+  <link name="right_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.002444 -0.003935 -0.144335" rpy="0 0 0" />
+      <mass value="2.002622" />
+      <inertia ixx="0.051833" ixy="7.1e-05" ixz="0.001432" iyy="0.052497" iyz="0.001457" izz="0.002461" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_yaw_joint" type="revolute">
+    <origin xyz="0 0 -0.136850000000023" rpy="0 0 0" />
+    <parent link="right_hip_roll_link" />
+    <child link="right_hip_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-3.43" upper="1.684" effort="120" velocity="11.936" />
+  </joint>
+  <link name="right_knee_link">
+    <inertial>
+      <origin xyz="-0.002699 -0.003794 -0.122288" rpy="0 0 0" />
+      <mass value="1.565881" />
+      <inertia ixx="0.03081" ixy="4.5e-05" ixz="0.000184" iyy="0.030822" iyz="0.000508" izz="0.001935" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_knee_joint" type="revolute">
+    <origin xyz="-0.00766000000003646 -0.000225000000000253 -0.183100000000014" rpy="0 0 0" />
+    <parent link="right_hip_yaw_link" />
+    <child link="right_knee_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="0" upper="2.4073" effort="120" velocity="11.936" />
+  </joint>
+  <link name="right_ankle_pitch_link">
+    <inertial>
+      <origin xyz="0.011665 0.000937 0.00394" rpy="0 0 0" />
+      <mass value="0.749566" />
+      <inertia ixx="0.001037" ixy="9e-06" ixz="-1.1e-05" iyy="0.001214" iyz="6.9e-05" izz="0.000723" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_pitch_joint" type="revolute">
+    <origin xyz="-0.00999999999984942 0.000124910735223305 -0.282000000000021" rpy="0 0 0" />
+    <parent link="right_knee_link" />
+    <child link="right_ankle_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.803" upper="0.453" effort="36" velocity="13.088" />
+  </joint>
+  <link name="right_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.035428 2.5e-05 -0.049572" rpy="0 0 0" />
+      <mass value="1.016166" />
+      <inertia ixx="0.0037" ixy="2e-06" ixz="-0.001872" iyy="0.007937" iyz="-1e-06" izz="0.005766" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_ankle_roll_link.STL" />
+      </geometry>
+      <material name="yellow">
+        <color rgba="1.0 0.5 0.0 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_ankle_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_roll_joint" type="revolute">
+    <origin xyz="-0.00174999998537372 0 0" rpy="0 0 0" />
+    <parent link="right_ankle_pitch_link" />
+    <child link="right_ankle_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.2625" upper="0.2625" effort="24" velocity="15.077" />
+  </joint>
+  <link name="waist_yaw_link">
+    <inertial>
+      <origin xyz="-0.001359 4.7e-05 0.041703" rpy="0 0 0" />
+      <mass value="1.668542" />
+      <inertia ixx="0.005012" ixy="1e-06" ixz="-0.000209" iyy="0.005" iyz="1e-06" izz="0.002852" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/waist_yaw_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    
+  </link>
+  <joint name="waist_yaw_joint" type="revolute">
+    <origin xyz="0 0 0.0670600000000297" rpy="0 0 0" />
+    <parent link="pelvis" />
+    <child link="waist_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-3.43" upper="2.382" effort="120" velocity="11.936" />
+  </joint>
+  <link name="waist_pitch_link">
+    <inertial>
+      <origin xyz="0.008967 -1e-06 0.0" rpy="0 0 0" />
+      <mass value="0.392413" />
+      <inertia ixx="0.000133" ixy="0.0" ixz="0.0" iyy="0.000133" iyz="0.0" izz="0.00023" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/waist_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    
+  </link>
+  <joint name="waist_pitch_joint" type="revolute">
+    <origin xyz="0 0 0.0880106468356499" rpy="0 0 0" />
+    <parent link="waist_yaw_link" />
+    <child link="waist_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.314" upper="0.314" effort="48" velocity="13.088" />
+  </joint>
+  <link name="torso_link">
+    <inertial>
+      <origin xyz="-0.000188 0.000605 0.191827" rpy="0 0 0" />
+      <mass value="10.144138" />
+      <inertia ixx="0.479751" ixy="0.000187" ixz="-0.00677" iyy="0.455998" iyz="0.000833" izz="0.066754" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/torso_plus_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/torso_plus_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="waist_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <parent link="waist_pitch_link" />
+    <child link="torso_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.488" upper="0.488" effort="48" velocity="13.088" />
+  </joint>
+  <link name="imu_in_torso_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/imu_in_torso_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.647058823529412 0.619607843137255 0.588235294117647 1" />
+      </material>
+    </visual>
+  </link>
+  <joint name="imu_in_torso_joint" type="fixed">
+    <origin xyz="-0.0248787003951661 0.0019852778697029 0.105938055641669" rpy="0 0 0" />
+    <parent link="torso_link" />
+    <child link="imu_in_torso_link" />
+    <axis xyz="0 0 0" />
+  </joint>
+  <link name="left_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0.003007 0.050014 6.2e-05" rpy="0 0 0" />
+      <mass value="0.885896" />
+      <inertia ixx="0.003023" ixy="0.000137" ixz="-2e-06" iyy="0.000685" iyz="1e-06" izz="0.002929" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.00329906676354264 0.143031506663431 0.241647721005027" rpy="0.209439453777995 0 0" />
+    <parent link="torso_link" />
+    <child link="left_shoulder_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-3.08" upper="2.04" effort="36" velocity="13.088" />
+  </joint>
+  <link name="left_shoulder_roll_link">
+    <inertial>
+      <origin xyz="0.000621 -0.000183 -0.078842" rpy="0 0 0" />
+      <mass value="0.706556" />
+      <inertia ixx="0.0054" ixy="0.0" ixz="-6.7e-05" iyy="0.005499" iyz="1.4e-05" izz="0.00054" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_roll_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_roll_joint" type="revolute">
+    <origin xyz="-0.000499991072907324 0.0495 0" rpy="0 0 0" />
+    <parent link="left_shoulder_pitch_link" />
+    <child link="left_shoulder_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.061" upper="2.993" effort="36" velocity="13.088" />
+  </joint>
+  <link name="left_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010005 0.000179 -0.069477" rpy="0 0 0" />
+      <mass value="0.704662" />
+      <inertia ixx="0.004291" ixy="0.0" ixz="-0.000607" iyy="0.004367" iyz="-8e-06" izz="0.000543" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0.00122423638490546 0 -0.121194848262102" rpy="0 -0.00597565694965793 0" />
+    <parent link="left_shoulder_roll_link" />
+    <child link="left_shoulder_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.556" upper="2.556" effort="24" velocity="15.077" />
+  </joint>
+  <link name="left_elbow_link">
+    <inertial>
+      <origin xyz="-0.013174 0.003788 -0.080203" rpy="0 0 0" />
+      <mass value="0.688008" />
+      <inertia ixx="0.00527" ixy="-1.9e-05" ixz="0.000743" iyy="0.005332" iyz="-9.4e-05" izz="0.000563" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_elbow_joint" type="revolute">
+    <origin xyz="0.0140000000488655 0.000199986464082369 -0.0829500000002385" rpy="0 0.00597565694965793 0" />
+    <parent link="left_shoulder_yaw_link" />
+    <child link="left_elbow_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.3556" upper="0" effort="24" velocity="15.077" />
+  </joint>
+  <link name="left_wrist_yaw_link">
+    <inertial>
+      <origin xyz="7.6e-05 0.007263 -0.030679" rpy="0 0 0" />
+      <mass value="0.360708" />
+      <inertia ixx="0.000612" ixy="-2e-06" ixz="1e-06" iyy="0.000507" iyz="-8e-05" izz="0.000208" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_wrist_yaw_joint" type="revolute">
+    <origin xyz="-0.0132797235062217 -9.75487744990788E-05 -0.120575783591803" rpy="0 0 0" />
+    <parent link="left_elbow_link" />
+    <child link="left_wrist_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.556" upper="2.556" effort="24" velocity="15.077" />
+  </joint>
+  <link name="left_wrist_pitch_link">
+    <inertial>
+      <origin xyz="0.011479 0.002282 0.001703" rpy="0 0 0" />
+      <mass value="0.292062" />
+      <inertia ixx="9.2e-05" ixy="7e-06" ixz="5e-06" iyy="0.000153" iyz="1.9e-05" izz="0.000163" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.3 0.3 0.3 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_wrist_pitch_joint" type="revolute">
+    <origin xyz="0.000490001227040848 0 -0.0819985359552045" rpy="0 -0.00597566028430406 0" />
+    <parent link="left_wrist_yaw_link" />
+    <child link="left_wrist_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.558" upper="0.558" effort="4.8" velocity="4.188" />
+  </joint>
+  <link name="left_wrist_roll_link">
+    <inertial>
+      <origin xyz="0.002935 -0.001499 -0.083026" rpy="0 0 0" />
+      <mass value="0.30304" />
+      <inertia ixx="0.002667" ixy="-2.8e-05" ixz="-0.000106" iyy="0.002772" iyz="4.9e-05" izz="0.000211" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.898039215686275 0.917647058823529 0.929411764705882 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_wrist_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <parent link="left_wrist_pitch_link" />
+    <child link="left_wrist_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-1.571" upper="0.724" effort="4.8" velocity="4.188" />
+  </joint>
+  <link name="right_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0.002721 -0.050304 3.4e-05" rpy="0 0 0" />
+      <mass value="0.885544" />
+      <inertia ixx="0.003031" ixy="-0.000123" ixz="-1e-06" iyy="0.000681" iyz="0.0" izz="0.002949" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.298039215686275 0.298039215686275 0.298039215686275 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.00330093831251838 -0.143030971450747 0.241648201390685" rpy="-0.209442812383636 0 0" />
+    <parent link="torso_link" />
+    <child link="right_shoulder_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-3.08" upper="2.04" effort="36" velocity="13.088" />
+  </joint>
+  <link name="right_shoulder_roll_link">
+    <inertial>
+      <origin xyz="0.000598 0.000185 -0.079928" rpy="0 0 0" />
+      <mass value="0.696963" />
+      <inertia ixx="0.0054" ixy="0.0" ixz="-3.8e-05" iyy="0.005489" iyz="-1.4e-05" izz="0.00053" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_roll_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_roll_joint" type="revolute">
+    <origin xyz="-0.000499999994070091 -0.0495000000000002 0" rpy="0 0.000154003092926045 0" />
+    <parent link="right_shoulder_pitch_link" />
+    <child link="right_shoulder_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.993" upper="0.061" effort="36" velocity="13.088" />
+  </joint>
+  <link name="right_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010082 -0.000178 -0.069484" rpy="0 0 0" />
+      <mass value="0.704661" />
+      <inertia ixx="0.004292" ixy="0.0" ixz="-0.000609" iyy="0.004366" iyz="8e-06" izz="0.000542" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0.000499999999999765 0 -0.121199999999934" rpy="0 0 0" />
+    <parent link="right_shoulder_roll_link" />
+    <child link="right_shoulder_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.556" upper="2.556" effort="24" velocity="15.077" />
+  </joint>
+  <link name="right_elbow_link">
+    <inertial>
+      <origin xyz="-0.013517 -0.003463 -0.080438" rpy="0 0 0" />
+      <mass value="0.687932" />
+      <inertia ixx="0.005285" ixy="1.7e-05" ixz="0.000767" iyy="0.005356" iyz="8e-05" izz="0.000567" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_elbow_joint" type="revolute">
+    <origin xyz="0.0139999999999662 -0.0002000000000143 -0.0829500000000745" rpy="0 0 0" />
+    <parent link="right_shoulder_yaw_link" />
+    <child link="right_elbow_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.3556" upper="0" effort="24" velocity="15.077" />
+  </joint>
+  <link name="right_wrist_yaw_link">
+    <inertial>
+      <origin xyz="0.000153 -0.006979 -0.032069" rpy="0 0 0" />
+      <mass value="0.372787" />
+      <inertia ixx="0.000696" ixy="2e-06" ixz="0.0" iyy="0.000583" iyz="7.7e-05" izz="0.000218" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_yaw_link.STL" />
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_wrist_yaw_joint" type="revolute">
+    <origin xyz="-0.0140000017961392 9.7526096753231E-05 -0.120694276209686" rpy="0 0 3.27341906322599E-05" />
+    <parent link="right_elbow_link" />
+    <child link="right_wrist_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.556" upper="2.556" effort="24" velocity="15.077" />
+  </joint>
+  <link name="right_wrist_pitch_link">
+    <inertial>
+      <origin xyz="0.012092 -0.002544 0.001781" rpy="0 0 0" />
+      <mass value="0.279175" />
+      <inertia ixx="8.3e-05" ixy="-8e-06" ixz="5e-06" iyy="0.000151" iyz="-1.9e-05" izz="0.000153" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.3 0.3 0.3 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_wrist_pitch_joint" type="revolute">
+    <origin xyz="0 0 -0.081799999999999" rpy="0 0 -3.27341932546355E-05" />
+    <parent link="right_wrist_yaw_link" />
+    <child link="right_wrist_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.558" upper="0.558" effort="4.8" velocity="4.188" />
+  </joint>
+  <link name="right_wrist_roll_link">
+    <inertial>
+      <origin xyz="0.003056 0.00138 -0.082799" rpy="0 0 0" />
+      <mass value="0.303847" />
+      <inertia ixx="0.002666" ixy="2.8e-05" ixz="-0.000112" iyy="0.002772" iyz="-4.6e-05" izz="0.000212" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.898039215686275 0.917647058823529 0.929411764705882 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_wrist_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <parent link="right_wrist_pitch_link" />
+    <child link="right_wrist_roll_link" />
+    <axis xyz="1 0 0" />
+    <limit lower="-0.724" upper="1.571" effort="4.8" velocity="4.188" />
+  </joint>
+  <link name="head_yaw_link">
+    <inertial>
+      <origin xyz="-0.003139 0.001399 0.051838" rpy="0 0 0" />
+      <mass value="0.720047" />
+      <inertia ixx="0.003861" ixy="9e-06" ixz="-2.1e-05" iyy="0.003231" iyz="-3.9e-05" izz="0.001103" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/head_yaw_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.866666666666667 0.866666666666667 0.890196078431372 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/head_yaw_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="head_yaw_joint" type="revolute">
+    <origin xyz="0.00834772789983268 0 0.309397077276121" rpy="0 0 0" />
+    <parent link="torso_link" />
+    <child link="head_yaw_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-0.366" upper="0.366" effort="2.6" velocity="6.019" />
+  </joint>
+  <link name="head_pitch_link">
+    <inertial>
+      <origin xyz="0.003033 -6e-05 0.004395" rpy="0 0 0" />
+      <mass value="0.999287" />
+      <inertia ixx="0.002913" ixy="1.7e-05" ixz="0.000147" iyy="0.003598" iyz="-2.2e-05" izz="0.002668" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/head_pitch_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.2 0.2 0.2 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/head_pitch_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="head_pitch_joint" type="revolute">
+    <origin xyz="0 0 0.0889" rpy="0 0 0" />
+    <parent link="head_yaw_link" />
+    <child link="head_pitch_link" />
+    <axis xyz="0 1 0" />
+    <limit lower="-0.3838" upper="0.3838" effort="0.6" velocity="6.28" />
+  </joint>
+  <link name="imu_in_head_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/imu_in_head_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.647058823529412 0.619607843137255 0.588235294117647 1" />
+      </material>
+    </visual>
+  </link>
+  <joint name="imu_in_head_joint" type="fixed">
+    <origin xyz="0.0259998716312927 -8.2538922380776E-05 0.0175999960932565" rpy="0 0 0" />
+    <parent link="head_pitch_link" />
+    <child link="imu_in_head_link" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  
+  
+  <link name="rgbd_head_front">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/rgbd_head_front_link.STL" />
+      </geometry>
+    </visual>
+  </link>
+  <joint name="rgbd_head_front" type="fixed">
+    <origin xyz="0.05761 -0.011183 -0.04837" rpy="2.2689 0 1.5708" />
+    <parent link="head_pitch_link" />
+    <child link="rgbd_head_front" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  
+  <link name="stereo_head_front">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/stereo_head_front_link.STL" />
+      </geometry>
+    </visual>
+  </link>
+  <joint name="stereo_head_front" type="fixed">
+    <origin xyz="0.067995 0.029784 0.05" rpy="-1.5708 0 -1.574" />
+    <parent link="head_pitch_link" />
+    <child link="stereo_head_front" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  
+  <link name="rgb_head_rear">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/rgb_head_rear_link.STL" />
+      </geometry>
+    </visual>
+  </link>
+  <joint name="rgb_head_rear" type="fixed">
+    <origin xyz="-0.0834 0.00026495 0" rpy="-1.5708 0 1.5676" />
+    <parent link="head_pitch_link" />
+    <child link="rgb_head_rear" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  
+  <link name="rgb_head_center">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="meshes/rgb_head_center_link.STL" />
+      </geometry>
+    </visual>
+  </link>
+  <joint name="rgb_head_center" type="fixed">
+    <origin xyz="0.0684 -0.00021713 0.05" rpy="-1.5708 0 -1.574" />
+    <parent link="head_pitch_link" />
+    <child link="rgb_head_center" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  
+  <link name="lidar_chest_front">
+    
+  </link>
+  <joint name="lidar_chest_front" type="fixed">
+    <origin xyz="0.102632855873251 0 0.181586916322065" rpy="-1.5707963267949 0 0" />
+    <parent link="torso_link" />
+    <child link="lidar_chest_front" />
+    <axis xyz="0 0 0" />
+  </joint>
+
+  <link name="base_link" />
+  <joint name="base_link_joint" type="fixed">
+    <origin xyz="0.0 0 0.0" rpy="0 0 0" />
+    <parent link="base_link" />
+    <child link="pelvis" />
+  </joint>
+
+</robot>

--- a/gear_sonic/data_process/convert_soma_csv_to_motion_lib.py
+++ b/gear_sonic/data_process/convert_soma_csv_to_motion_lib.py
@@ -2,10 +2,12 @@
 # ruff: noqa: T201, DOC
 """Convert SOMA retargeter CSV/PKL data to motion_lib format for SONIC training.
 
-SOMA retargeter outputs G1 29-DOF motion data as CSV files (joint_pos.csv,
+SOMA retargeter outputs robot motion data as CSV files (joint_pos.csv,
 body_pos.csv, body_quat.csv) or as a joblib PKL with the same fields. This
 script converts that data into the motion_lib PKL format expected by SONIC
 training (root_trans_offset, pose_aa, dof, root_rot, fps).
+
+Supports Unitree G1 (29 DOF) and Agibot X2 Ultra (31 DOF) via --robot flag.
 
 Supports five input modes:
   1. Single motion directory with CSVs (joint_pos.csv, body_pos.csv, body_quat.csv)
@@ -15,30 +17,17 @@ Supports five input modes:
   5. Parent directory of session dirs containing Bones-SEED CSVs
 
 Usage:
-    # Single CSV directory
-    python scripts/motion/convert_soma_csv_to_motion_lib.py \
-        --input data/soma_retarget/tired_squat_003__A360 \
-        --output data/soma_test.pkl --fps 50
-
-    # Batch: parent dir with multiple motion subdirs
-    python scripts/motion/convert_soma_csv_to_motion_lib.py \
-        --input data/soma_retarget/all_demo_4seqs \
-        --output data/soma_demo_4seqs.pkl --fps 50
-
-    # Deploy PKL file
-    python scripts/motion/convert_soma_csv_to_motion_lib.py \
-        --input data/soma_retarget/bones_test.pkl \
-        --output data/soma_bones_test.pkl --fps 50
-
-    # Bones-SEED: directory of flat CSVs (single session)
-    python scripts/motion/convert_soma_csv_to_motion_lib.py \
-        --input /path/to/bones_SEED/g1/csv/210531 \
-        --output data/bones_seed_210531.pkl --fps 50
-
-    # Bones-SEED: all sessions (parent dir)
-    python scripts/motion/convert_soma_csv_to_motion_lib.py \
+    # Bones-SEED G1 CSVs (default)
+    python gear_sonic/data_process/convert_soma_csv_to_motion_lib.py \
         --input /path/to/bones_SEED/g1/csv \
-        --output data/bones_seed_all.pkl --fps 50
+        --output data/bones_seed_all.pkl --fps 30 --fps_source 120
+
+    # X2 Ultra CSVs from SOMA Retargeter
+    python gear_sonic/data_process/convert_soma_csv_to_motion_lib.py \
+        --robot x2_ultra \
+        --input /path/to/x2_ultra_csvs/ \
+        --output data/x2_ultra_motions/robot \
+        --fps 30 --fps_source 120 --individual --num_workers 16
 """
 
 import argparse
@@ -49,117 +38,100 @@ import joblib
 import numpy as np
 from scipy.spatial import transform
 
-# IsaacLab ↔ MuJoCo joint reordering (29 DOFs for G1).
-# MJ_TO_IL[mj] = il: for MuJoCo DOF index mj, gives the IsaacLab index il.
-# Source: external_dependencies/SONIC_Web/demo_python.py
-MJ_TO_IL = np.array(
-    [
-        0,
-        3,
-        6,
-        9,
-        13,
-        17,
-        1,
-        4,
-        7,
-        10,
-        14,
-        18,
-        2,
-        5,
-        8,
-        11,
-        15,
-        19,
-        21,
-        23,
-        25,
-        27,
-        12,
-        16,
-        20,
-        22,
-        24,
-        26,
-        28,
-    ],
+
+# ---------------------------------------------------------------------------
+# G1 29-DOF robot constants
+# ---------------------------------------------------------------------------
+
+G1_MJ_TO_IL = np.array(
+    [0, 3, 6, 9, 13, 17, 1, 4, 7, 10, 14, 18, 2, 5, 8, 11, 15, 19,
+     21, 23, 25, 27, 12, 16, 20, 22, 24, 26, 28],
     dtype=np.int32,
 )
 
-# G1 29-DOF axis definitions (from Humanoid_Batch / g1_29dof_rev_1_0.xml).
-# Each DOF rotates around a single axis. Hardcoded to avoid torch dependency.
-NUM_DOF = 29
-NUM_BODIES = 30  # pelvis + 29 actuated links
-DOF_AXIS = np.array(
+G1_NUM_DOF = 29
+G1_NUM_BODIES = 30
+G1_DOF_AXIS = np.array(
     [
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 0, 1],
-        [0, 1, 0],
-        [0, 1, 0],
-        [1, 0, 0],  # left leg
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 0, 1],
-        [0, 1, 0],
-        [0, 1, 0],
-        [1, 0, 0],  # right leg
-        [0, 0, 1],
-        [1, 0, 0],
-        [0, 1, 0],  # waist
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 0, 1],
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1],  # left arm
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 0, 1],
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1],  # right arm
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 0], [1, 0, 0],  # left leg
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 0], [1, 0, 0],  # right leg
+        [0, 0, 1], [1, 0, 0], [0, 1, 0],                                      # waist
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],  # left arm
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],  # right arm
     ],
     dtype=np.float32,
 )
 
+G1_MJCF_FILE = "g1_29dof_rev_1_0.xml"
 
-# Joint names in Bones-SEED CSV column order (after Frame + 6 root columns).
-# These are in MuJoCo/MJCF actuator order (same as g1_29dof_rev_1_0.xml motors).
-BONES_CSV_JOINT_NAMES = [
-    "left_hip_pitch_joint_dof",
-    "left_hip_roll_joint_dof",
-    "left_hip_yaw_joint_dof",
-    "left_knee_joint_dof",
-    "left_ankle_pitch_joint_dof",
-    "left_ankle_roll_joint_dof",
-    "right_hip_pitch_joint_dof",
-    "right_hip_roll_joint_dof",
-    "right_hip_yaw_joint_dof",
-    "right_knee_joint_dof",
-    "right_ankle_pitch_joint_dof",
-    "right_ankle_roll_joint_dof",
-    "waist_yaw_joint_dof",
-    "waist_roll_joint_dof",
-    "waist_pitch_joint_dof",
-    "left_shoulder_pitch_joint_dof",
-    "left_shoulder_roll_joint_dof",
-    "left_shoulder_yaw_joint_dof",
-    "left_elbow_joint_dof",
-    "left_wrist_roll_joint_dof",
-    "left_wrist_pitch_joint_dof",
-    "left_wrist_yaw_joint_dof",
-    "right_shoulder_pitch_joint_dof",
-    "right_shoulder_roll_joint_dof",
-    "right_shoulder_yaw_joint_dof",
-    "right_elbow_joint_dof",
-    "right_wrist_roll_joint_dof",
-    "right_wrist_pitch_joint_dof",
-    "right_wrist_yaw_joint_dof",
-]
+
+# ---------------------------------------------------------------------------
+# X2 Ultra 31-DOF robot constants
+# Axis order matches CSV column order from AgibotX2Ultra31DOF_CSVConfig and
+# the MuJoCo DOF mapping in gear_sonic/envs/manager_env/robots/x2_ultra.py.
+# ---------------------------------------------------------------------------
+
+X2_MJ_TO_IL = np.array(
+    [0, 3, 6, 9, 14, 19, 1, 4, 7, 10, 15, 20, 2, 5, 8, 11, 16, 21,
+     23, 25, 27, 29, 12, 17, 22, 24, 26, 28, 30, 13, 18],
+    dtype=np.int32,
+)
+
+X2_NUM_DOF = 31
+X2_NUM_BODIES = 32
+X2_DOF_AXIS = np.array(
+    [
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 0], [1, 0, 0],  # left leg
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 0], [1, 0, 0],  # right leg
+        [0, 0, 1], [0, 1, 0], [1, 0, 0],                                      # waist
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0],                          # left shoulder+elbow
+        [0, 0, 1], [0, 1, 0], [1, 0, 0],                                      # left wrist
+        [0, 1, 0], [1, 0, 0], [0, 0, 1], [0, 1, 0],                          # right shoulder+elbow
+        [0, 0, 1], [0, 1, 0], [1, 0, 0],                                      # right wrist
+        [0, 0, 1], [0, 1, 0],                                                  # head
+    ],
+    dtype=np.float32,
+)
+
+X2_MJCF_FILE = "x2_ultra.xml"
+
+
+# ---------------------------------------------------------------------------
+# Robot config registry
+# ---------------------------------------------------------------------------
+
+ROBOT_CONFIGS = {
+    "g1": {
+        "mj_to_il": G1_MJ_TO_IL,
+        "num_dof": G1_NUM_DOF,
+        "num_bodies": G1_NUM_BODIES,
+        "dof_axis": G1_DOF_AXIS,
+        "mjcf_file": G1_MJCF_FILE,
+    },
+    "x2_ultra": {
+        "mj_to_il": X2_MJ_TO_IL,
+        "num_dof": X2_NUM_DOF,
+        "num_bodies": X2_NUM_BODIES,
+        "dof_axis": X2_DOF_AXIS,
+        "mjcf_file": X2_MJCF_FILE,
+    },
+}
+
+# Active robot config (set in main() from --robot arg)
+MJ_TO_IL = G1_MJ_TO_IL
+NUM_DOF = G1_NUM_DOF
+NUM_BODIES = G1_NUM_BODIES
+DOF_AXIS = G1_DOF_AXIS
+
+
+def set_robot(robot_type: str):
+    """Set module-level robot constants from the config registry."""
+    global MJ_TO_IL, NUM_DOF, NUM_BODIES, DOF_AXIS  # noqa: PLW0603
+    cfg = ROBOT_CONFIGS[robot_type]
+    MJ_TO_IL = cfg["mj_to_il"]
+    NUM_DOF = cfg["num_dof"]
+    NUM_BODIES = cfg["num_bodies"]
+    DOF_AXIS = cfg["dof_axis"]
 
 
 def load_bones_csv(csv_path: str) -> dict:
@@ -326,19 +298,20 @@ def downsample_sequence(entry: dict, fps_source: int, fps_target: int) -> dict:
     }
 
 
-def init_humanoid_fk():
-    """Initialize Humanoid_Batch from the G1 MJCF config.
+def init_humanoid_fk(robot_type: str = "g1"):
+    """Initialize Humanoid_Batch from the robot's MJCF config.
 
     Only needed for non-Bones-SEED inputs (deploy PKL, SOMA CSV dirs).
     Bones-SEED path uses hardcoded DOF_AXIS constants instead.
     """
     import omegaconf
 
+    cfg = ROBOT_CONFIGS[robot_type]
     motion_cfg = omegaconf.OmegaConf.create(
         {
             "asset": {
                 "assetRoot": "gear_sonic/data/assets/robot_description/mjcf/",
-                "assetFileName": "g1_29dof_rev_1_0.xml",
+                "assetFileName": cfg["mjcf_file"],
                 "urdfFileName": "",
             },
             "extend_config": [],
@@ -351,10 +324,11 @@ def init_humanoid_fk():
 
 def process_session_csvs(args_tuple):
     """Process all CSVs in a single session directory. Used by multiprocessing."""
-    session_dir, session_name, out_dir, fps, fps_source = args_tuple
+    session_dir, session_name, out_dir, fps, fps_source, robot_type = args_tuple
     import warnings
 
     warnings.filterwarnings("ignore")
+    set_robot(robot_type)
 
     csv_files = sorted([f for f in os.listdir(session_dir) if f.endswith(".csv")])
 
@@ -391,6 +365,13 @@ def main():
         "--output", required=True, help="Output path (PKL file or directory for individual PKLs)"
     )
     parser.add_argument(
+        "--robot",
+        type=str,
+        default="g1",
+        choices=list(ROBOT_CONFIGS.keys()),
+        help="Target robot type (default: g1)",
+    )
+    parser.add_argument(
         "--fps",
         type=int,
         default=30,
@@ -416,7 +397,8 @@ def main():
     )
     args = parser.parse_args()
 
-    print(f"G1 {NUM_DOF} DOFs, {NUM_BODIES} bodies (hardcoded axes)")
+    set_robot(args.robot)
+    print(f"{args.robot}: {NUM_DOF} DOFs, {NUM_BODIES} bodies")
 
     # Individual PKL mode: skip scanning, go straight to parallel per-session processing
     if args.individual:
@@ -443,10 +425,10 @@ def main():
             for d in subdirs:
                 subdir = os.path.join(args.input, d)
                 if any(f.endswith(".csv") for f in os.listdir(subdir)):
-                    session_dirs.append((subdir, d, args.output, args.fps, args.fps_source))
+                    session_dirs.append((subdir, d, args.output, args.fps, args.fps_source, args.robot))
         elif has_csvs:
             session_name = os.path.basename(args.input.rstrip("/"))
-            session_dirs.append((args.input, session_name, args.output, args.fps, args.fps_source))
+            session_dirs.append((args.input, session_name, args.output, args.fps, args.fps_source, args.robot))
 
         print(f"\nBatch converting {len(session_dirs)} sessions with {args.num_workers} workers")
         print(f"Output: {args.output}")

--- a/gear_sonic/envs/manager_env/mdp/commands.py
+++ b/gear_sonic/envs/manager_env/mdp/commands.py
@@ -612,8 +612,9 @@ class TrackingCommand(CommandTerm):
 
         # Inject body/DOF mapping into motion_lib_cfg so motion_lib handles
         # body reordering and xyzw→wxyz quaternion conversion at load time.
-
-        isaaclab_to_mujoco_mapping = order_converter.G1Converter().get_isaaclab_to_mujoco_mapping()
+        asset_file = motion_lib_cfg.get("asset", {}).get("assetFileName", "g1_29dof_rev_1_0.xml")
+        converter = order_converter.get_converter_for_mjcf(asset_file)
+        isaaclab_to_mujoco_mapping = converter.get_isaaclab_to_mujoco_mapping()
         motion_lib_cfg.update(
             {
                 "mujoco_to_isaaclab_body": isaaclab_to_mujoco_mapping["mujoco_to_isaaclab_body"],

--- a/gear_sonic/envs/manager_env/modular_tracking_env_cfg.py
+++ b/gear_sonic/envs/manager_env/modular_tracking_env_cfg.py
@@ -16,7 +16,7 @@ import joblib
 import pxr
 
 from gear_sonic.envs.manager_env.mdp import terrain
-from gear_sonic.envs.manager_env.robots import g1, h2
+from gear_sonic.envs.manager_env.robots import g1, h2, x2_ultra
 from gear_sonic.trl.utils import common
 
 
@@ -1005,6 +1005,11 @@ class ModularTrackingEnvCfg(ManagerBasedRLEnvCfg):
                 "robot_cfg": h2.H2_CFG,
                 "action_scale": h2.H2_ACTION_SCALE,
                 "isaaclab_to_mujoco_mapping": h2.H2_ISAACLAB_TO_MUJOCO_MAPPING,
+            },
+            "x2_ultra": {
+                "robot_cfg": x2_ultra.X2_ULTRA_CFG,
+                "action_scale": x2_ultra.X2_ULTRA_ACTION_SCALE,
+                "isaaclab_to_mujoco_mapping": x2_ultra.X2_ULTRA_ISAACLAB_TO_MUJOCO_MAPPING,
             },
         }
 

--- a/gear_sonic/envs/manager_env/robots/__init__.py
+++ b/gear_sonic/envs/manager_env/robots/__init__.py
@@ -2,3 +2,4 @@
 # Import from gear_sonic.envs.manager_env.robots.g1 or .h2 directly for new code.
 from gear_sonic.envs.manager_env.robots.g1 import *  # noqa: F401,F403
 from gear_sonic.envs.manager_env.robots.h2 import *  # noqa: F401,F403
+from gear_sonic.envs.manager_env.robots.x2_ultra import *  # noqa: F401,F403

--- a/gear_sonic/envs/manager_env/robots/x2_ultra.py
+++ b/gear_sonic/envs/manager_env/robots/x2_ultra.py
@@ -1,0 +1,303 @@
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets.articulation import ArticulationCfg
+import isaaclab.sim as sim_utils
+
+ASSET_DIR = "gear_sonic/data/assets"
+
+# Agibot X2 Ultra motor parameters.
+# Exact rotor inertia (armature) values are not available from the vendor;
+# using H2 motor constants as starting estimates grouped by torque class.
+# These MUST be tuned once real motor datasheets are obtained.
+ARMATURE_HIP_KNEE = 0.025101925  # 120 N-m class (hip pitch/roll/yaw, knee)
+ARMATURE_WAIST_YAW = 0.010177520  # 120 N-m waist yaw
+ARMATURE_WAIST_PR = 0.003609725  # 48 N-m waist pitch/roll
+ARMATURE_ANKLE = 0.003609725  # 36/24 N-m ankle
+ARMATURE_SHOULDER_ELBOW = 0.003609725  # 36/24 N-m shoulder/elbow
+ARMATURE_WRIST = 0.00425  # 4.8 N-m wrist pitch/roll
+ARMATURE_WRIST_YAW = 0.003609725  # 24 N-m wrist yaw
+ARMATURE_HEAD = 0.00425  # 2.6/0.6 N-m head
+
+NATURAL_FREQ = 10 * 2.0 * 3.1415926535  # 10 Hz
+DAMPING_RATIO = 2.0
+
+STIFFNESS_HIP_KNEE = ARMATURE_HIP_KNEE * NATURAL_FREQ**2
+STIFFNESS_WAIST_YAW = ARMATURE_WAIST_YAW * NATURAL_FREQ**2
+STIFFNESS_WAIST_PR = ARMATURE_WAIST_PR * NATURAL_FREQ**2
+STIFFNESS_ANKLE = ARMATURE_ANKLE * NATURAL_FREQ**2
+STIFFNESS_SHOULDER_ELBOW = ARMATURE_SHOULDER_ELBOW * NATURAL_FREQ**2
+STIFFNESS_WRIST = ARMATURE_WRIST * NATURAL_FREQ**2
+STIFFNESS_WRIST_YAW = ARMATURE_WRIST_YAW * NATURAL_FREQ**2
+STIFFNESS_HEAD = ARMATURE_HEAD * NATURAL_FREQ**2
+
+DAMPING_HIP_KNEE = 2.0 * DAMPING_RATIO * ARMATURE_HIP_KNEE * NATURAL_FREQ
+DAMPING_WAIST_YAW = 2.0 * DAMPING_RATIO * ARMATURE_WAIST_YAW * NATURAL_FREQ
+DAMPING_WAIST_PR = 2.0 * DAMPING_RATIO * ARMATURE_WAIST_PR * NATURAL_FREQ
+DAMPING_ANKLE = 2.0 * DAMPING_RATIO * ARMATURE_ANKLE * NATURAL_FREQ
+DAMPING_SHOULDER_ELBOW = 2.0 * DAMPING_RATIO * ARMATURE_SHOULDER_ELBOW * NATURAL_FREQ
+DAMPING_WRIST = 2.0 * DAMPING_RATIO * ARMATURE_WRIST * NATURAL_FREQ
+DAMPING_WRIST_YAW = 2.0 * DAMPING_RATIO * ARMATURE_WRIST_YAW * NATURAL_FREQ
+DAMPING_HEAD = 2.0 * DAMPING_RATIO * ARMATURE_HEAD * NATURAL_FREQ
+
+# Body names in IsaacLab BFS traversal order (32 bodies including root pelvis).
+# Derived by BFS traversal of the URDF kinematic tree, skipping fixed-joint-only links.
+X2_ULTRA_ISAACLAB_JOINTS = [
+    "pelvis",
+    "left_hip_pitch_link",
+    "right_hip_pitch_link",
+    "waist_yaw_link",
+    "left_hip_roll_link",
+    "right_hip_roll_link",
+    "waist_pitch_link",
+    "left_hip_yaw_link",
+    "right_hip_yaw_link",
+    "torso_link",
+    "left_knee_link",
+    "right_knee_link",
+    "left_shoulder_pitch_link",
+    "right_shoulder_pitch_link",
+    "head_yaw_link",
+    "left_ankle_pitch_link",
+    "right_ankle_pitch_link",
+    "left_shoulder_roll_link",
+    "right_shoulder_roll_link",
+    "head_pitch_link",
+    "left_ankle_roll_link",
+    "right_ankle_roll_link",
+    "left_shoulder_yaw_link",
+    "right_shoulder_yaw_link",
+    "left_elbow_link",
+    "right_elbow_link",
+    "left_wrist_yaw_link",
+    "right_wrist_yaw_link",
+    "left_wrist_pitch_link",
+    "right_wrist_pitch_link",
+    "left_wrist_roll_link",
+    "right_wrist_roll_link",
+]
+
+# DOF index mappings between IsaacLab and MuJoCo orderings (31 DOF).
+# isaaclab_to_mujoco[i] = MuJoCo index of the joint at IsaacLab index i.
+X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF = [
+    0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 15, 22, 29, 4, 10,
+    16, 23, 30, 5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28,
+]
+X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF = [
+    0, 3, 6, 9, 14, 19, 1, 4, 7, 10, 15, 20, 2, 5, 8, 11,
+    16, 21, 23, 25, 27, 29, 12, 17, 22, 24, 26, 28, 30, 13, 18,
+]
+
+# Body index mappings between IsaacLab and MuJoCo orderings (32 bodies).
+X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY = [
+    0, 1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 23, 30, 5,
+    11, 17, 24, 31, 6, 12, 18, 25, 19, 26, 20, 27, 21, 28, 22, 29,
+]
+X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY = [
+    0, 1, 4, 7, 10, 15, 20, 2, 5, 8, 11, 16, 21, 3, 6, 9,
+    12, 17, 22, 24, 26, 28, 30, 13, 18, 23, 25, 27, 29, 31, 14, 19,
+]
+
+X2_ULTRA_ISAACLAB_TO_MUJOCO_MAPPING = {
+    "isaaclab_joints": X2_ULTRA_ISAACLAB_JOINTS,
+    "isaaclab_to_mujoco_dof": X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF,
+    "mujoco_to_isaaclab_dof": X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF,
+    "isaaclab_to_mujoco_body": X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY,
+    "mujoco_to_isaaclab_body": X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY,
+}
+
+
+X2_ULTRA_CFG = ArticulationCfg(
+    spawn=sim_utils.UrdfFileCfg(
+        fix_base=False,
+        replace_cylinders_with_capsules=True,
+        asset_path=f"{ASSET_DIR}/robot_description/urdf/x2_ultra/x2_ultra.urdf",
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            retain_accelerations=False,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=1000.0,
+            max_depenetration_velocity=1.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=True,
+            solver_position_iteration_count=8,
+            solver_velocity_iteration_count=4,
+        ),
+        joint_drive=sim_utils.UrdfConverterCfg.JointDriveCfg(
+            gains=sim_utils.UrdfConverterCfg.JointDriveCfg.PDGainsCfg(stiffness=0, damping=0)
+        ),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        # X2 Ultra pelvis height is ~0.68m in MJCF default pose;
+        # spawn slightly higher to avoid ground clipping with bent knees.
+        pos=(0.0, 0.0, 0.78),
+        joint_pos={
+            ".*_hip_pitch_joint": -0.312,
+            ".*_knee_joint": 0.669,
+            ".*_ankle_pitch_joint": -0.363,
+            ".*_elbow_joint": -0.6,
+            "left_shoulder_roll_joint": 0.2,
+            "left_shoulder_pitch_joint": 0.2,
+            "right_shoulder_roll_joint": -0.2,
+            "right_shoulder_pitch_joint": 0.2,
+        },
+        joint_vel={".*": 0.0},
+    ),
+    soft_joint_pos_limit_factor=0.9,
+    actuators={
+        "legs": ImplicitActuatorCfg(
+            joint_names_expr=[
+                ".*_hip_yaw_joint",
+                ".*_hip_roll_joint",
+                ".*_hip_pitch_joint",
+                ".*_knee_joint",
+            ],
+            effort_limit_sim={
+                ".*_hip_yaw_joint": 120.0,
+                ".*_hip_roll_joint": 120.0,
+                ".*_hip_pitch_joint": 120.0,
+                ".*_knee_joint": 120.0,
+            },
+            velocity_limit_sim={
+                ".*_hip_yaw_joint": 11.936,
+                ".*_hip_roll_joint": 11.936,
+                ".*_hip_pitch_joint": 11.936,
+                ".*_knee_joint": 11.936,
+            },
+            stiffness={
+                ".*_hip_pitch_joint": STIFFNESS_HIP_KNEE,
+                ".*_hip_roll_joint": STIFFNESS_HIP_KNEE,
+                ".*_hip_yaw_joint": STIFFNESS_HIP_KNEE,
+                ".*_knee_joint": STIFFNESS_HIP_KNEE,
+            },
+            damping={
+                ".*_hip_pitch_joint": DAMPING_HIP_KNEE,
+                ".*_hip_roll_joint": DAMPING_HIP_KNEE,
+                ".*_hip_yaw_joint": DAMPING_HIP_KNEE,
+                ".*_knee_joint": DAMPING_HIP_KNEE,
+            },
+            armature={
+                ".*_hip_pitch_joint": ARMATURE_HIP_KNEE,
+                ".*_hip_roll_joint": ARMATURE_HIP_KNEE,
+                ".*_hip_yaw_joint": ARMATURE_HIP_KNEE,
+                ".*_knee_joint": ARMATURE_HIP_KNEE,
+            },
+        ),
+        "feet": ImplicitActuatorCfg(
+            joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
+            effort_limit_sim={
+                ".*_ankle_pitch_joint": 36.0,
+                ".*_ankle_roll_joint": 24.0,
+            },
+            velocity_limit_sim={
+                ".*_ankle_pitch_joint": 13.088,
+                ".*_ankle_roll_joint": 15.077,
+            },
+            stiffness=STIFFNESS_ANKLE,
+            damping=DAMPING_ANKLE,
+            armature=ARMATURE_ANKLE,
+        ),
+        "waist_yaw": ImplicitActuatorCfg(
+            joint_names_expr=["waist_yaw_joint"],
+            effort_limit_sim=120.0,
+            velocity_limit_sim=11.936,
+            stiffness=STIFFNESS_WAIST_YAW,
+            damping=DAMPING_WAIST_YAW,
+            armature=ARMATURE_WAIST_YAW,
+        ),
+        "waist": ImplicitActuatorCfg(
+            joint_names_expr=["waist_pitch_joint", "waist_roll_joint"],
+            effort_limit_sim=48.0,
+            velocity_limit_sim=13.088,
+            stiffness=STIFFNESS_WAIST_PR,
+            damping=DAMPING_WAIST_PR,
+            armature=ARMATURE_WAIST_PR,
+        ),
+        "head": ImplicitActuatorCfg(
+            joint_names_expr=["head_yaw_joint", "head_pitch_joint"],
+            effort_limit_sim={
+                "head_yaw_joint": 2.6,
+                "head_pitch_joint": 0.6,
+            },
+            velocity_limit_sim={
+                "head_yaw_joint": 6.019,
+                "head_pitch_joint": 6.28,
+            },
+            stiffness=STIFFNESS_HEAD,
+            damping=DAMPING_HEAD,
+            armature=ARMATURE_HEAD,
+        ),
+        "arms": ImplicitActuatorCfg(
+            joint_names_expr=[
+                ".*_shoulder_pitch_joint",
+                ".*_shoulder_roll_joint",
+                ".*_shoulder_yaw_joint",
+                ".*_elbow_joint",
+                ".*_wrist_yaw_joint",
+                ".*_wrist_pitch_joint",
+                ".*_wrist_roll_joint",
+            ],
+            effort_limit_sim={
+                ".*_shoulder_pitch_joint": 36.0,
+                ".*_shoulder_roll_joint": 36.0,
+                ".*_shoulder_yaw_joint": 24.0,
+                ".*_elbow_joint": 24.0,
+                ".*_wrist_yaw_joint": 24.0,
+                ".*_wrist_pitch_joint": 4.8,
+                ".*_wrist_roll_joint": 4.8,
+            },
+            velocity_limit_sim={
+                ".*_shoulder_pitch_joint": 13.088,
+                ".*_shoulder_roll_joint": 13.088,
+                ".*_shoulder_yaw_joint": 15.077,
+                ".*_elbow_joint": 15.077,
+                ".*_wrist_yaw_joint": 15.077,
+                ".*_wrist_pitch_joint": 4.188,
+                ".*_wrist_roll_joint": 4.188,
+            },
+            stiffness={
+                ".*_shoulder_pitch_joint": STIFFNESS_SHOULDER_ELBOW,
+                ".*_shoulder_roll_joint": STIFFNESS_SHOULDER_ELBOW,
+                ".*_shoulder_yaw_joint": STIFFNESS_SHOULDER_ELBOW,
+                ".*_elbow_joint": STIFFNESS_SHOULDER_ELBOW,
+                ".*_wrist_yaw_joint": STIFFNESS_WRIST_YAW,
+                ".*_wrist_pitch_joint": STIFFNESS_WRIST,
+                ".*_wrist_roll_joint": STIFFNESS_WRIST,
+            },
+            damping={
+                ".*_shoulder_pitch_joint": DAMPING_SHOULDER_ELBOW,
+                ".*_shoulder_roll_joint": DAMPING_SHOULDER_ELBOW,
+                ".*_shoulder_yaw_joint": DAMPING_SHOULDER_ELBOW,
+                ".*_elbow_joint": DAMPING_SHOULDER_ELBOW,
+                ".*_wrist_yaw_joint": DAMPING_WRIST_YAW,
+                ".*_wrist_pitch_joint": DAMPING_WRIST,
+                ".*_wrist_roll_joint": DAMPING_WRIST,
+            },
+            armature={
+                ".*_shoulder_pitch_joint": ARMATURE_SHOULDER_ELBOW,
+                ".*_shoulder_roll_joint": ARMATURE_SHOULDER_ELBOW,
+                ".*_shoulder_yaw_joint": ARMATURE_SHOULDER_ELBOW,
+                ".*_elbow_joint": ARMATURE_SHOULDER_ELBOW,
+                ".*_wrist_yaw_joint": ARMATURE_WRIST_YAW,
+                ".*_wrist_pitch_joint": ARMATURE_WRIST,
+                ".*_wrist_roll_joint": ARMATURE_WRIST,
+            },
+        ),
+    },
+)
+
+# Action scale: effort_limit / stiffness * 0.25 (same formula as H2)
+X2_ULTRA_ACTION_SCALE = {}
+for a in X2_ULTRA_CFG.actuators.values():
+    e = a.effort_limit_sim
+    s = a.stiffness
+    names = a.joint_names_expr
+    if not isinstance(e, dict):
+        e = dict.fromkeys(names, e)
+    if not isinstance(s, dict):
+        s = dict.fromkeys(names, s)
+    for n in names:
+        if n in e and n in s and s[n]:
+            X2_ULTRA_ACTION_SCALE[n] = 0.25 * e[n] / s[n]

--- a/gear_sonic/envs/manager_env/robots/x2_ultra.py
+++ b/gear_sonic/envs/manager_env/robots/x2_ultra.py
@@ -39,7 +39,9 @@ DAMPING_WRIST_YAW = 2.0 * DAMPING_RATIO * ARMATURE_WRIST_YAW * NATURAL_FREQ
 DAMPING_HEAD = 2.0 * DAMPING_RATIO * ARMATURE_HEAD * NATURAL_FREQ
 
 # Body names in IsaacLab BFS traversal order (32 bodies including root pelvis).
-# Derived by BFS traversal of the URDF kinematic tree, skipping fixed-joint-only links.
+# Verified against runtime robot.joint_names.  Isaac Lab sorts children
+# alphabetically within each BFS level, so head_yaw_link ("h") precedes
+# left/right_shoulder_pitch_link ("l"/"r") at the same depth.
 X2_ULTRA_ISAACLAB_JOINTS = [
     "pelvis",
     "left_hip_pitch_link",
@@ -53,14 +55,14 @@ X2_ULTRA_ISAACLAB_JOINTS = [
     "torso_link",
     "left_knee_link",
     "right_knee_link",
+    "head_yaw_link",
     "left_shoulder_pitch_link",
     "right_shoulder_pitch_link",
-    "head_yaw_link",
     "left_ankle_pitch_link",
     "right_ankle_pitch_link",
+    "head_pitch_link",
     "left_shoulder_roll_link",
     "right_shoulder_roll_link",
-    "head_pitch_link",
     "left_ankle_roll_link",
     "right_ankle_roll_link",
     "left_shoulder_yaw_link",
@@ -78,30 +80,33 @@ X2_ULTRA_ISAACLAB_JOINTS = [
 # DOF index mappings between IsaacLab and MuJoCo orderings (31 DOF).
 # isaaclab_to_mujoco[i] = MuJoCo index of the joint at IsaacLab index i.
 X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF = [
-    0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 15, 22, 29, 4, 10,
-    16, 23, 30, 5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28,
+    0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 29, 15, 22, 4, 10,
+    30, 16, 23, 5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28,
 ]
 X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF = [
-    0, 3, 6, 9, 14, 19, 1, 4, 7, 10, 15, 20, 2, 5, 8, 11,
-    16, 21, 23, 25, 27, 29, 12, 17, 22, 24, 26, 28, 30, 13, 18,
+    0, 3, 6, 9, 14, 19, 1, 4, 7, 10, 15, 20, 2, 5, 8, 12,
+    17, 21, 23, 25, 27, 29, 13, 18, 22, 24, 26, 28, 30, 11, 16,
 ]
 
 # Body index mappings between IsaacLab and MuJoCo orderings (32 bodies).
 X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY = [
-    0, 1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 23, 30, 5,
-    11, 17, 24, 31, 6, 12, 18, 25, 19, 26, 20, 27, 21, 28, 22, 29,
+    0, 1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 30, 16, 23, 5,
+    11, 31, 17, 24, 6, 12, 18, 25, 19, 26, 20, 27, 21, 28, 22, 29,
 ]
 X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY = [
     0, 1, 4, 7, 10, 15, 20, 2, 5, 8, 11, 16, 21, 3, 6, 9,
-    12, 17, 22, 24, 26, 28, 30, 13, 18, 23, 25, 27, 29, 31, 14, 19,
+    13, 18, 22, 24, 26, 28, 30, 14, 19, 23, 25, 27, 29, 31, 12, 17,
 ]
 
 X2_ULTRA_ISAACLAB_TO_MUJOCO_MAPPING = {
     "isaaclab_joints": X2_ULTRA_ISAACLAB_JOINTS,
-    "isaaclab_to_mujoco_dof": X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF,
-    "mujoco_to_isaaclab_dof": X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF,
-    "isaaclab_to_mujoco_body": X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY,
-    "mujoco_to_isaaclab_body": X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY,
+    # The motion_lib code uses these as numpy/torch gather indices:
+    #   dof_il = dof_mj[mapping[i]]  →  mapping[i] must be the MJ source for IL position i
+    # G1 follows this convention; X2 arrays are swapped to match.
+    "isaaclab_to_mujoco_dof": X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF,
+    "mujoco_to_isaaclab_dof": X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF,
+    "isaaclab_to_mujoco_body": X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY,
+    "mujoco_to_isaaclab_body": X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY,
 }
 
 

--- a/gear_sonic/scripts/dump_isaaclab_step0.py
+++ b/gear_sonic/scripts/dump_isaaclab_step0.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Dump IsaacLab step-0 observations and policy intermediates for MuJoCo comparison.
+
+This is a thin wrapper around ``gear_sonic.eval_agent_trl`` that monkey-patches
+``UniversalTokenModule.forward`` to capture, on the first call only, all the
+intermediate tensors needed to verify the MuJoCo deployment script:
+
+    * Parsed tokenizer obs dict (every term)
+    * Encoder input (concat of g1 inputs)
+    * Encoder latent BEFORE FSQ quantization
+    * Token AFTER FSQ quantization
+    * Token-flattened (decoder input slice)
+    * Proprioception (decoder input slice)
+    * Decoder output (action_mean)
+    * Robot ground-truth state at the SAME instant
+      (joint_pos, joint_vel, root_pos, root_quat_wxyz, root_lin_vel_w,
+       root_ang_vel_w) for every env
+
+After the dump is written, ``sys.exit(0)`` is called so we don't waste time
+running the full eval loop.
+
+Usage:
+    python gear_sonic/scripts/dump_isaaclab_step0.py \\
+        +checkpoint=logs_rl/.../model_step_006000.pt \\
+        +headless=True \\
+        ++num_envs=1 \\
+        ++eval_callbacks=im_eval \\
+        ++run_eval_loop=true \\
+        ++max_render_steps=1 \\
+        ++dump_path=/tmp/x2_step0_isaaclab.pt
+"""
+
+import os
+import sys
+import pickle
+import torch
+
+# Ensure we can import the eval module (it lives under gear_sonic/)
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+_DUMP_PATH = None
+for _arg in sys.argv:
+    if _arg.startswith("++dump_path=") or _arg.startswith("dump_path="):
+        _DUMP_PATH = _arg.split("=", 1)[1]
+        break
+if _DUMP_PATH is None:
+    _DUMP_PATH = "/tmp/x2_step0_isaaclab.pt"
+sys.argv = [a for a in sys.argv if not (a.startswith("++dump_path=") or a.startswith("dump_path="))]
+
+print(f"[dump_isaaclab_step0] Will dump to: {_DUMP_PATH}", flush=True)
+
+
+def _install_forward_dump_patch():
+    """Monkey-patch UniversalTokenModule.forward to capture step-0 tensors."""
+    from gear_sonic.trl.modules import universal_token_modules as utm
+
+    original_forward = utm.UniversalTokenModule.forward
+    state = {"called": False}
+
+    def patched_forward(self, input_data, compute_aux_loss=False, return_dict=False, **kwargs):
+        if state["called"]:
+            return original_forward(
+                self, input_data, compute_aux_loss=compute_aux_loss,
+                return_dict=return_dict, **kwargs
+            )
+        state["called"] = True
+        print(f"[dump_isaaclab_step0] First UniversalTokenModule.forward call — capturing.",
+              flush=True)
+
+        # Reproduce the encode→quantize→decode logic so we can capture intermediates.
+        batch_size, seq_len = input_data["actor_obs"].shape[:2]
+        tokenizer_obs = self.parse_tokenizer_obs(input_data)
+        proprioception_input = torch.cat(
+            [input_data[key] for key in self.proprioception_features], dim=-1
+        )
+
+        # Run the g1 encoder on the LAST timestep only (mirrors evaluation use)
+        # to get encoder input + latent + token.
+        encoder_name = "g1"
+        input_features = self.encoder_input_features[encoder_name]
+        obs_list = [tokenizer_obs[key] for key in input_features]
+        encoder_input_full = torch.cat(obs_list, dim=-1)  # (B, S, T_in, F_per_t)
+        # Flatten batch+seq the same way the encoder does
+        encoder_input_flat = encoder_input_full.view(-1, *encoder_input_full.shape[2:])
+        # (B*S, num_input_temporal_dims, feature_per_t) -> (B*S, num_input_temporal_dims*feature_per_t)
+        encoder_input_for_mlp = encoder_input_flat.view(encoder_input_flat.shape[0], -1)
+
+        encoder = self.encoders[encoder_name]
+        with torch.no_grad():
+            latent = encoder(encoder_input_flat)  # (B*S, max_num_tokens, token_dim)
+
+            quantized = None
+            if self.quantizer is not None:
+                quantized, _ = self.quantizer(latent)
+            else:
+                quantized = latent
+
+            token_flattened = quantized.reshape(
+                batch_size, seq_len, self.max_num_tokens * self.token_dim
+            )
+
+            # Decode through g1_dyn
+            decoder_name = "g1_dyn"
+            decoder = self.decoders[decoder_name]
+            decoder_input = torch.cat(
+                [token_flattened, proprioception_input], dim=-1
+            )
+            decoder_out = decoder(decoder_input)
+
+        dump = {
+            "actor_obs_shape": tuple(input_data["actor_obs"].shape),
+            "tokenizer_shape": tuple(input_data["tokenizer"].shape),
+            "actor_obs": input_data["actor_obs"].detach().cpu(),
+            "tokenizer_flat": input_data["tokenizer"].detach().cpu(),
+            "proprioception_input": proprioception_input.detach().cpu(),
+            "tokenizer_obs": {
+                k: v.detach().cpu() for k, v in tokenizer_obs.items()
+            },
+            "tokenizer_obs_dims": dict(self.tokenizer_obs_dims),
+            "tokenizer_obs_names": list(self.tokenizer_obs_names),
+            "encoder_input_features": dict(self.encoder_input_features),
+            "encoder_input_full": encoder_input_full.detach().cpu(),
+            "encoder_input_flat": encoder_input_flat.detach().cpu(),
+            "encoder_input_for_mlp_view": encoder_input_for_mlp.detach().cpu(),
+            "encoder_latent_g1": latent.detach().cpu(),
+            "fsq_token_g1": quantized.detach().cpu(),
+            "token_flattened": token_flattened.detach().cpu(),
+            "decoder_input": decoder_input.detach().cpu(),
+            "decoder_action_mean": decoder_out.detach().cpu(),
+            "max_num_tokens": int(self.max_num_tokens),
+            "token_dim": int(self.token_dim),
+            "num_future_frames": int(self.num_future_frames),
+            "proprioception_features": list(self.proprioception_features),
+        }
+
+        # Try to capture ground-truth robot state from the env via the global
+        # reference saved by the eval entry point (see _capture_env_state).
+        env_state = _ENV_STATE_HOLDER.get("state", None)
+        if env_state is not None:
+            dump["env_state"] = env_state
+            print(f"[dump_isaaclab_step0] Captured env GT state with keys: "
+                  f"{list(env_state.keys())}", flush=True)
+
+        torch.save(dump, _DUMP_PATH)
+        print(f"[dump_isaaclab_step0] Wrote dump to {_DUMP_PATH}", flush=True)
+        print(f"  actor_obs shape: {dump['actor_obs_shape']}", flush=True)
+        print(f"  tokenizer flat shape: {dump['tokenizer_shape']}", flush=True)
+        print(f"  encoder_input_full shape: {tuple(encoder_input_full.shape)}", flush=True)
+        print(f"  encoder_latent_g1 shape: {tuple(latent.shape)}", flush=True)
+        print(f"  fsq_token_g1 shape: {tuple(quantized.shape)}", flush=True)
+        print(f"  decoder_action_mean shape: {tuple(decoder_out.shape)}", flush=True)
+        print(f"  decoder_action_mean[0]: {decoder_out[0].cpu().numpy()}", flush=True)
+
+        # Bail out cleanly so we don't run the full eval
+        os._exit(0)
+
+    utm.UniversalTokenModule.forward = patched_forward
+    print("[dump_isaaclab_step0] Installed forward dump patch on UniversalTokenModule.",
+          flush=True)
+
+
+_ENV_STATE_HOLDER = {"state": None}
+
+
+def _install_env_state_patch():
+    """Patch env.reset_all to capture GT robot state right after reset."""
+
+    from gear_sonic import train_agent_trl
+
+    original_create = train_agent_trl.create_manager_env
+
+    def patched_create(*args, **kwargs):
+        env = original_create(*args, **kwargs)
+        original_reset_all = env.reset_all
+
+        def patched_reset_all(*a, **kw):
+            obs = original_reset_all(*a, **kw)
+            try:
+                # env.env is the IsaacLab ManagerBasedRLEnv
+                inner_env = env.env if hasattr(env, "env") else env
+                scene = inner_env.scene
+                robot = scene["robot"]
+
+                # robot.data exposes joint_pos, joint_vel, root_pos_w, root_quat_w (wxyz), etc.
+                gt = {
+                    "joint_pos": robot.data.joint_pos.detach().cpu(),
+                    "joint_vel": robot.data.joint_vel.detach().cpu(),
+                    "root_pos_w": robot.data.root_pos_w.detach().cpu(),
+                    "root_quat_w_wxyz": robot.data.root_quat_w.detach().cpu(),
+                    "root_lin_vel_w": robot.data.root_lin_vel_w.detach().cpu(),
+                    "root_ang_vel_w": robot.data.root_ang_vel_w.detach().cpu(),
+                    "root_lin_vel_b": robot.data.root_lin_vel_b.detach().cpu(),
+                    "root_ang_vel_b": robot.data.root_ang_vel_b.detach().cpu(),
+                    "joint_names": list(robot.data.joint_names),
+                    "default_joint_pos": robot.data.default_joint_pos.detach().cpu(),
+                }
+
+                # Try to capture motion-command info too
+                try:
+                    cmd = inner_env.command_manager.get_term("motion")
+                    gt["motion_ids"] = cmd.motion_ids.detach().cpu()
+                    gt["motion_times"] = cmd.motion_times.detach().cpu()
+                    if hasattr(cmd, "future_motion_ids"):
+                        gt["future_motion_ids"] = cmd.future_motion_ids.detach().cpu()
+                    if hasattr(cmd, "future_time_steps"):
+                        gt["future_time_steps"] = cmd.future_time_steps.detach().cpu()
+                    if hasattr(cmd, "num_future_frames"):
+                        gt["num_future_frames"] = int(cmd.num_future_frames)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[dump_isaaclab_step0] Warning: motion command capture failed: {exc}",
+                          flush=True)
+
+                _ENV_STATE_HOLDER["state"] = gt
+                print(f"[dump_isaaclab_step0] Captured GT env state. "
+                      f"joint_pos[0,:6]={gt['joint_pos'][0,:6].numpy()}, "
+                      f"root_pos_w[0]={gt['root_pos_w'][0].numpy()}, "
+                      f"root_quat_w_wxyz[0]={gt['root_quat_w_wxyz'][0].numpy()}",
+                      flush=True)
+            except Exception as exc:  # noqa: BLE001
+                import traceback
+                traceback.print_exc()
+                print(f"[dump_isaaclab_step0] Warning: env state capture failed: {exc}",
+                      flush=True)
+
+            return obs
+
+        env.reset_all = patched_reset_all
+        return env
+
+    train_agent_trl.create_manager_env = patched_create
+    print("[dump_isaaclab_step0] Installed env state capture patch.", flush=True)
+
+
+def main():
+    # Install patches FIRST so any subsequent imports (and especially the env
+    # creation) see the patched versions.
+    _install_env_state_patch()
+    _install_forward_dump_patch()
+
+    # Hydra's @hydra.main resolves config_path relative to the script file that
+    # owns the decorator. To keep that resolution working, we hand control to
+    # the eval script via runpy as if it were the entry point — this is what
+    # Hydra expects rather than importing main() from another module.
+    import runpy
+    eval_script_path = os.path.join(_REPO_ROOT, "gear_sonic", "eval_agent_trl.py")
+    print(f"[dump_isaaclab_step0] Handing off to {eval_script_path}", flush=True)
+    sys.argv[0] = eval_script_path
+    runpy.run_path(eval_script_path, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/scripts/eval_x2_mujoco.py
+++ b/gear_sonic/scripts/eval_x2_mujoco.py
@@ -1,0 +1,765 @@
+#!/usr/bin/env python3
+"""Evaluate a trained SONIC checkpoint for the X2 Ultra in MuJoCo.
+
+Loads a .pt checkpoint, reconstructs the universal-token actor (g1 encoder
++ g1_dyn decoder), reads the motion-lib PKL for reference commands, and
+runs a PD-control loop in MuJoCo with on-screen rendering.
+
+The robot is reset to the motion's frame-``--init-frame`` state using
+Reference State Initialization (RSI) — the same teleport-into-the-motion
+trick that IsaacLab does at every episode reset. RSI sets joint pos+vel
+and root pos+quat+lin_vel+ang_vel from the motion, then physics takes
+over and the policy must keep tracking.
+
+Whenever the robot falls (pelvis drops below ``--fall-height``) or tips
+over (gravity_body z > ``--fall-tilt-cos``) the episode is auto-reset to
+the same RSI state — same as IsaacLab's termination/reset cycle. This
+lets the policy keep getting fresh in-distribution starts during a long
+viewer session.
+
+Usage:
+    python gear_sonic/scripts/eval_x2_mujoco.py \\
+        --checkpoint logs_rl/.../model_step_006000.pt \\
+        --motion gear_sonic/data/motions/x2_ultra_walk_forward.pkl
+
+    Optional:
+      --init-frame N         RSI motion frame (default 0)
+      --fall-height 0.4      Pelvis z below this (m) triggers a reset
+      --fall-tilt-cos -0.3   gravity_body[z] above this triggers a reset
+                             (i.e. body tilted >~70° off upright)
+      --max-episode 10.0     Force-reset after this many seconds (s)
+
+Controls:
+    SPACE - Pause / resume
+    R     - Manually reset
+    V     - Toggle camera tracking / free camera
+"""
+
+import argparse
+import collections
+import math
+import time
+from pathlib import Path
+
+import joblib
+import mujoco
+import mujoco.viewer
+import numpy as np
+import torch
+import torch.nn as nn
+from scipy.spatial.transform import Rotation as Rot
+
+GEAR_SONIC_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# ---------- X2 Ultra constants ----------
+NUM_DOFS = 31
+HISTORY_LEN = 10
+CONTROL_DT = 0.02
+SIM_DT = 0.005
+DECIMATION = 4
+NUM_FUTURE_FRAMES = 10
+DT_FUTURE_REF = 0.1
+
+MJCF_PATH = str(GEAR_SONIC_ROOT / "gear_sonic/data/assets/robot_description/mjcf/x2_ultra.xml")
+
+MUJOCO_JOINT_NAMES = [
+    "left_hip_pitch_joint", "left_hip_roll_joint", "left_hip_yaw_joint",
+    "left_knee_joint", "left_ankle_pitch_joint", "left_ankle_roll_joint",
+    "right_hip_pitch_joint", "right_hip_roll_joint", "right_hip_yaw_joint",
+    "right_knee_joint", "right_ankle_pitch_joint", "right_ankle_roll_joint",
+    "waist_yaw_joint", "waist_pitch_joint", "waist_roll_joint",
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint", "left_elbow_joint",
+    "left_wrist_yaw_joint", "left_wrist_pitch_joint", "left_wrist_roll_joint",
+    "right_shoulder_pitch_joint", "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint", "right_elbow_joint",
+    "right_wrist_yaw_joint", "right_wrist_pitch_joint", "right_wrist_roll_joint",
+    "head_yaw_joint", "head_pitch_joint",
+]
+
+JOINT_TO_ACTUATOR = [
+    0, 1, 2, 3, 4, 5,
+    6, 7, 8, 9, 10, 11,
+    12, 13, 14,
+    17, 18, 19, 20, 21, 22, 23,
+    24, 25, 26, 27, 28, 29, 30,
+    15, 16,
+]
+
+IL_TO_MJ_DOF = [
+    0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 29, 15, 22, 4, 10,
+    30, 16, 23, 5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28,
+]
+MJ_TO_IL_DOF = [
+    0, 3, 6, 9, 14, 19, 1, 4, 7, 10, 15, 20, 2, 5, 8, 12,
+    17, 21, 23, 25, 27, 29, 13, 18, 22, 24, 26, 28, 30, 11, 16,
+]
+
+NATURAL_FREQ = 10 * 2.0 * math.pi
+DAMPING_RATIO = 2.0
+
+# Default joint positions from x2_ultra.py InitialStateCfg (training reset pose)
+DEFAULT_JOINT_POS = {
+    "hip_pitch": -0.312,
+    "knee": 0.669,
+    "ankle_pitch": -0.363,
+    "elbow": -0.6,
+    "left_shoulder_roll": 0.2,
+    "left_shoulder_pitch": 0.2,
+    "right_shoulder_roll": -0.2,
+    "right_shoulder_pitch": 0.2,
+}
+
+# Effort limits from x2_ultra.py actuator config
+EFFORT_LIMITS = {
+    "hip_yaw": 120.0, "hip_roll": 120.0, "hip_pitch": 120.0, "knee": 120.0,
+    "ankle_pitch": 36.0, "ankle_roll": 24.0,
+    "waist_yaw": 120.0, "waist_pitch": 48.0, "waist_roll": 48.0,
+    "shoulder_pitch": 36.0, "shoulder_roll": 36.0, "shoulder_yaw": 24.0, "elbow": 24.0,
+    "wrist_yaw": 24.0, "wrist_pitch": 4.8, "wrist_roll": 4.8,
+    "head_yaw": 2.6, "head_pitch": 0.6,
+}
+
+ARMATURES = {
+    "hip": 0.025101925, "knee": 0.025101925,
+    "waist_yaw": 0.010177520, "waist_pitch": 0.003609725, "waist_roll": 0.003609725,
+    "ankle": 0.003609725,
+    "shoulder": 0.003609725, "elbow": 0.003609725,
+    "wrist_yaw": 0.003609725, "wrist_pitch": 0.00425, "wrist_roll": 0.00425,
+    "head": 0.00425,
+}
+
+
+def _compute_gains_and_scales():
+    kp = np.zeros(NUM_DOFS, dtype=np.float64)
+    kd = np.zeros(NUM_DOFS, dtype=np.float64)
+    action_scale = np.ones(NUM_DOFS, dtype=np.float64)
+    default_pos = np.zeros(NUM_DOFS, dtype=np.float64)
+
+    for i, jname in enumerate(MUJOCO_JOINT_NAMES):
+        # PD gains from armature
+        for key, arm in ARMATURES.items():
+            if key in jname:
+                kp[i] = arm * NATURAL_FREQ**2
+                kd[i] = 2.0 * DAMPING_RATIO * arm * NATURAL_FREQ
+                break
+
+        # Action scale = 0.25 * effort / stiffness
+        short = jname.replace("_joint", "").replace("left_", "").replace("right_", "")
+        for ekey, effort in EFFORT_LIMITS.items():
+            if ekey in jname.replace("_joint", ""):
+                action_scale[i] = 0.25 * effort / kp[i]
+                break
+
+        # Default positions
+        for dkey, dval in DEFAULT_JOINT_POS.items():
+            if dkey == "left_shoulder_roll" and jname == "left_shoulder_roll_joint":
+                default_pos[i] = dval; break
+            elif dkey == "left_shoulder_pitch" and jname == "left_shoulder_pitch_joint":
+                default_pos[i] = dval; break
+            elif dkey == "right_shoulder_roll" and jname == "right_shoulder_roll_joint":
+                default_pos[i] = dval; break
+            elif dkey == "right_shoulder_pitch" and jname == "right_shoulder_pitch_joint":
+                default_pos[i] = dval; break
+            elif dkey in jname.replace("_joint", "") and "shoulder" not in dkey:
+                default_pos[i] = dval; break
+
+    return kp, kd, action_scale, default_pos
+
+
+KP, KD, ACTION_SCALE, DEFAULT_DOF = _compute_gains_and_scales()
+
+
+# ---------- Actor ----------
+class SimpleMLP(nn.Module):
+    def __init__(self, layer_sizes):
+        super().__init__()
+        layers = []
+        for i in range(len(layer_sizes) - 1):
+            layers.append(nn.Linear(layer_sizes[i], layer_sizes[i + 1]))
+            if i < len(layer_sizes) - 2:
+                layers.append(nn.SiLU())
+        self.module = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.module(x)
+
+
+def fsq_quantize(z, levels=32):
+    """Replicate vector_quantize_pytorch.FSQ with uniform `levels`-per-dim.
+
+    Matches FSQ.bound() exactly:
+        half_l = (L-1) * (1+eps) / 2
+        offset = 0.5 if L%2==0 else 0
+        shift  = atanh(offset / half_l)
+        bounded = tanh(z + shift) * half_l - offset
+        return round(bounded) / (L // 2)
+
+    The training config uses num_fsq_levels=32, fsq_level_list=32, so dim==
+    effective_codebook_dim and FSQ.project_in/out are nn.Identity (no params).
+    """
+    L = float(levels)
+    eps = 1e-3
+    half_l = (L - 1.0) * (1.0 + eps) / 2.0
+    offset = 0.5 if int(levels) % 2 == 0 else 0.0
+    shift = math.atanh(offset / half_l) if offset != 0.0 else 0.0
+    bounded = torch.tanh(z + shift) * half_l - offset
+    return torch.round(bounded) / (int(levels) // 2)
+
+
+class UniversalTokenActor(nn.Module):
+    """Reproduces gear_sonic.trl.modules.universal_token_modules.UniversalTokenModule
+    inference path for a single g1 encoder + g1_dyn decoder + FSQ quantizer.
+
+    Pipeline (matches universal_token_modules.encode + decode for g1/g1_dyn):
+        tokenizer_obs(680) ── encoder MLP ──► 64
+                          ── reshape(B, 2, 32) ──► FSQ(quantize) ──► (B, 2, 32)
+                          ── flatten ──► token_flattened (B, 64)
+        cat([token_flattened, proprioception(990)]) ──► decoder MLP ──► action(31)
+
+    FSQ is a fixed deterministic bound+round (32 levels per dim) — no params.
+    """
+
+    MAX_NUM_TOKENS = 2
+    TOKEN_DIM = 32
+    FSQ_LEVELS = 32
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = SimpleMLP([680, 2048, 1024, 512, 512, 64])
+        self.decoder = SimpleMLP([1054, 2048, 2048, 1024, 1024, 512, 512, 31])
+        self.std = nn.Parameter(torch.zeros(31))
+
+    def forward(self, proprioception, tokenizer_obs):
+        # Encoder produces 64-dim continuous latent
+        latent = self.encoder(tokenizer_obs)
+        # Reshape to (B, num_tokens, token_dim) = (B, 2, 32)
+        latent = latent.view(*latent.shape[:-1], self.MAX_NUM_TOKENS, self.TOKEN_DIM)
+        # FSQ quantize (bound + round) — same shape
+        quantized = fsq_quantize(latent, levels=self.FSQ_LEVELS)
+        # Flatten back to token_flattened (B, 64)
+        token_flat = quantized.view(*quantized.shape[:-2], -1)
+        decoder_input = torch.cat([token_flat, proprioception], dim=-1)
+        return self.decoder(decoder_input)
+
+
+def load_actor_from_checkpoint(ckpt_path: str, device: str = "cpu"):
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+    sd = ckpt.get("policy_state_dict") or ckpt.get("actor_model_state_dict")
+    if sd is None:
+        raise KeyError("Cannot find policy state dict in checkpoint")
+    actor = UniversalTokenActor()
+    new_sd = {}
+    for k, v in sd.items():
+        if k == "std":
+            new_sd["std"] = v
+        elif k.startswith("actor_module.encoders.g1.module."):
+            new_sd[k.replace("actor_module.encoders.g1.module.", "encoder.module.")] = v
+        elif k.startswith("actor_module.decoders.g1_dyn.module."):
+            new_sd[k.replace("actor_module.decoders.g1_dyn.module.", "decoder.module.")] = v
+    actor.load_state_dict(new_sd)
+    actor.eval()
+    return actor.to(device)
+
+
+# ---------- Motion helpers ----------
+def load_motion_data(path):
+    return joblib.load(path)
+
+
+def _m(data):
+    return data[list(data.keys())[0]]
+
+
+def get_total_frames(data):
+    return _m(data)["dof"].shape[0]
+
+
+def get_motion_fps(data):
+    return float(_m(data)["fps"])
+
+
+def compute_motion_state(motion_data, frame, fps):
+    """Reconstruct the full robot reset state from a motion frame.
+
+    Mirrors IsaacLab's Reference State Initialization (RSI) in
+    ``TrackingCommand`` (see ``gear_sonic/envs/manager_env/mdp/commands.py``
+    ``write_joint_state_to_sim`` / ``write_root_state_to_sim``): at reset,
+    the simulator teleports the robot to the motion's frame ``f`` state —
+    joint pos+vel, root pos+quat+lin_vel+ang_vel — bypassing physics. We
+    reproduce that here so MuJoCo starts in the same distribution the
+    policy was trained on.
+
+    The PKL stores joint DOFs in **MuJoCo order**, ``root_trans_offset`` in
+    world frame, and ``root_rot`` as a scipy-style **xyzw** quaternion.
+    Velocities are not stored in the PKL, so we reconstruct them with a
+    one-step forward finite difference (matches IsaacLab's motion-lib
+    ``dof_vels`` and ``global_root_velocity`` to ~1e-2 precision).
+
+    Returns a dict with:
+        joint_pos_mj      (31,) MuJoCo joint order
+        joint_vel_mj      (31,) MuJoCo joint order
+        root_pos_w        (3,)  world-frame xyz
+        root_quat_w_wxyz  (4,)  MuJoCo wxyz quaternion
+        root_lin_vel_w    (3,)  world-frame linear vel
+        root_ang_vel_w    (3,)  world-frame angular vel (axis-angle / dt)
+    """
+    m = _m(motion_data)
+    n_frames = m["dof"].shape[0]
+    f = int(frame) % n_frames
+    f_next = min(f + 1, n_frames - 1)
+    dt = 1.0 / float(fps)
+
+    joint_pos_mj = np.asarray(m["dof"][f], dtype=np.float64)
+    if f_next != f:
+        joint_vel_mj = (np.asarray(m["dof"][f_next], dtype=np.float64) - joint_pos_mj) / dt
+    else:
+        joint_vel_mj = np.zeros(NUM_DOFS, dtype=np.float64)
+
+    root_pos_w = np.asarray(m["root_trans_offset"][f], dtype=np.float64).copy()
+
+    # PKL root_rot is xyzw (scipy). MuJoCo qpos[3:7] is wxyz.
+    quat_xyzw = np.asarray(m["root_rot"][f], dtype=np.float64)
+    root_quat_w_wxyz = np.array(
+        [quat_xyzw[3], quat_xyzw[0], quat_xyzw[1], quat_xyzw[2]], dtype=np.float64
+    )
+
+    if f_next != f:
+        root_lin_vel_w = (
+            np.asarray(m["root_trans_offset"][f_next], dtype=np.float64) - root_pos_w
+        ) / dt
+        q_next_xyzw = np.asarray(m["root_rot"][f_next], dtype=np.float64)
+        rel = Rot.from_quat(q_next_xyzw) * Rot.from_quat(quat_xyzw).inv()
+        root_ang_vel_w = rel.as_rotvec() / dt
+    else:
+        root_lin_vel_w = np.zeros(3, dtype=np.float64)
+        root_ang_vel_w = np.zeros(3, dtype=np.float64)
+
+    return {
+        "joint_pos_mj": joint_pos_mj,
+        "joint_vel_mj": joint_vel_mj,
+        "root_pos_w": root_pos_w,
+        "root_quat_w_wxyz": root_quat_w_wxyz,
+        "root_lin_vel_w": root_lin_vel_w,
+        "root_ang_vel_w": root_ang_vel_w,
+    }
+
+
+# ---------- Observation construction ----------
+# IsaacLab observation layout for policy group (concatenate_terms=True).
+# CRITICAL: term order follows the PolicyCfg dataclass ATTRIBUTE order
+# (gear_sonic/envs/manager_env/mdp/observations.py lines 107-128), NOT the
+# YAML ordering. The PolicyAtmCfg comment confirms it explicitly:
+#   "Order matches PolicyCfg: base_ang_vel, joint_pos, joint_vel, actions, gravity_dir"
+# Each term: history_length=10, oldest at index 0, newest at index max_length-1
+# (CircularBuffer.buffer property; broadcast-fills all slots with first sample
+# at reset). Layout (oldest..newest within each term):
+#   base_ang_vel  (3)  x 10 -> 30
+#   joint_pos_rel (31) x 10 -> 310
+#   joint_vel     (31) x 10 -> 310
+#   last_action   (31) x 10 -> 310
+#   gravity_dir   (3)  x 10 -> 30
+# Total proprioception: 990
+# Verified via /tmp/x2_step0_isaaclab.pt dump (slicing each block matched the
+# corresponding env_state quantity within the configured noise tolerance).
+
+def quat_rotate_inverse(q_wxyz, v):
+    """Rotate vector v by the INVERSE of quaternion q (wxyz convention).
+
+    Matches IsaacLab's quat_apply_inverse: v - w*t + cross(u, t).
+    """
+    w, x, y, z = q_wxyz
+    u = np.array([x, y, z])
+    t = 2.0 * np.cross(u, v)
+    return v - w * t + np.cross(u, t)
+
+
+class ProprioceptionBuffer:
+    """Maintains per-term history buffers matching IsaacLab's layout.
+
+    Mirrors IsaacLab's ``CircularBuffer`` semantics: at reset the buffer is
+    empty, and the first ``append`` after reset broadcast-fills all
+    ``HISTORY_LEN`` slots with the first observation (see IsaacLab
+    ``circular_buffer.py``: ``buffer`` returns the full history with the
+    first sample replicated until the buffer fills naturally).
+
+    Without this priming we would inject ``HISTORY_LEN-1`` zeroed frames
+    into the proprioception, which is OOD for any policy trained with
+    history.
+    """
+
+    def __init__(self):
+        self.gravity_hist = collections.deque(maxlen=HISTORY_LEN)
+        self.angvel_hist = collections.deque(maxlen=HISTORY_LEN)
+        self.jpos_hist = collections.deque(maxlen=HISTORY_LEN)
+        self.jvel_hist = collections.deque(maxlen=HISTORY_LEN)
+        self.action_hist = collections.deque(maxlen=HISTORY_LEN)
+        self._primed = False
+
+    def reset(self):
+        self.gravity_hist.clear()
+        self.angvel_hist.clear()
+        self.jpos_hist.clear()
+        self.jvel_hist.clear()
+        self.action_hist.clear()
+        self._primed = False
+
+    def append(self, gravity, angvel, jpos_rel, jvel, action):
+        g = gravity.astype(np.float32)
+        a = angvel.astype(np.float32)
+        jp = jpos_rel.astype(np.float32)
+        jv = jvel.astype(np.float32)
+        ac = action.astype(np.float32)
+        if not self._primed:
+            for _ in range(HISTORY_LEN):
+                self.gravity_hist.append(g)
+                self.angvel_hist.append(a)
+                self.jpos_hist.append(jp)
+                self.jvel_hist.append(jv)
+                self.action_hist.append(ac)
+            self._primed = True
+        else:
+            self.gravity_hist.append(g)
+            self.angvel_hist.append(a)
+            self.jpos_hist.append(jp)
+            self.jvel_hist.append(jv)
+            self.action_hist.append(ac)
+
+    def get_flat(self) -> np.ndarray:
+        """Return 990-dim proprioception in IsaacLab term-by-term layout.
+
+        Term order MUST match ``PolicyCfg`` dataclass attribute order:
+            base_ang_vel, joint_pos, joint_vel, actions, gravity_dir.
+        Within each term, frames are oldest-first (CircularBuffer convention).
+        """
+        parts = []
+        for hist in [self.angvel_hist, self.jpos_hist, self.jvel_hist,
+                     self.action_hist, self.gravity_hist]:
+            for frame in hist:
+                parts.append(frame)
+        return np.concatenate(parts).astype(np.float32)
+
+
+def build_tokenizer_obs(motion_data, current_time, base_quat_wxyz, motion_fps):
+    """Build 680-dim tokenizer input matching IsaacLab's exact layout.
+
+    Training layout (from command_multi_future + motion_anchor_ori_b_mf):
+      command_flat = cat([jpos_flat(10*31=310), jvel_flat(10*31=310)]) = 620
+      command_nonflat = command_flat.reshape(10, 62)
+      ori_nonflat = 6D_rot_diff per frame, shape (10, 6)
+      encoder_input = cat(command_nonflat, ori_nonflat, dim=-1) = (10, 68)
+      flattened to 680
+    """
+    m = _m(motion_data)
+    total_frames = m["dof"].shape[0]
+    dt = 1.0 / motion_fps
+
+    cur_rot = Rot.from_quat([base_quat_wxyz[1], base_quat_wxyz[2],
+                              base_quat_wxyz[3], base_quat_wxyz[0]])
+
+    # Collect 10 future frames of jpos and jvel (in IsaacLab DOF order)
+    jpos_frames = []  # each (31,) in IL order
+    jvel_frames = []  # each (31,) in IL order
+    ori_frames = []   # each (6,) 6D rotation diff
+
+    for f in range(NUM_FUTURE_FRAMES):
+        future_time = current_time + (f + 1) * DT_FUTURE_REF
+        fi = min(int(future_time / dt), total_frames - 1)
+
+        jpos_il = m["dof"][fi][IL_TO_MJ_DOF]
+        jpos_frames.append(jpos_il.astype(np.float32))
+
+        prev_fi = max(0, fi - 1)
+        jvel_mj = (m["dof"][fi] - m["dof"][prev_fi]) * motion_fps
+        jvel_il = jvel_mj[IL_TO_MJ_DOF]
+        jvel_frames.append(jvel_il.astype(np.float32))
+
+        # root_rot is xyzw in the PKL (scipy convention)
+        fq = m["root_rot"][fi]
+        future_rot = Rot.from_quat(fq)
+        relative = cur_rot.inv() * future_rot
+        rot_mat = relative.as_matrix()
+        ori_6d = np.concatenate([rot_mat[:, 0], rot_mat[:, 1]]).astype(np.float32)
+        ori_frames.append(ori_6d)
+
+    # Replicate IsaacLab's layout: cat([all_jpos_flat, all_jvel_flat]).reshape(10, 62)
+    jpos_flat = np.concatenate(jpos_frames)  # (310,)
+    jvel_flat = np.concatenate(jvel_frames)  # (310,)
+    command_flat = np.concatenate([jpos_flat, jvel_flat])  # (620,)
+    command_nonflat = command_flat.reshape(NUM_FUTURE_FRAMES, -1)  # (10, 62)
+
+    ori_nonflat = np.stack(ori_frames)  # (10, 6)
+
+    encoder_input = np.concatenate([command_nonflat, ori_nonflat], axis=-1)  # (10, 68)
+    return encoder_input.reshape(-1).astype(np.float32)  # (680,)
+
+
+# ---------- Main ----------
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--motion", required=True)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument(
+        "--init-frame",
+        type=int,
+        default=0,
+        help="Motion frame to RSI-initialize the robot at (default 0).",
+    )
+    parser.add_argument(
+        "--fall-height",
+        type=float,
+        default=0.4,
+        help="If pelvis world z drops below this (m), auto-reset (default 0.4).",
+    )
+    parser.add_argument(
+        "--fall-tilt-cos",
+        type=float,
+        default=-0.3,
+        help="If gravity in body frame's z component goes above this, auto-reset. "
+        "-1.0 = perfectly upright, 0.0 = horizontal. Default -0.3 ~ 72° tilt.",
+    )
+    parser.add_argument(
+        "--max-episode",
+        type=float,
+        default=0.0,
+        help="If > 0, force a reset after this many simulated seconds (default 0 = no limit).",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading actor from {args.checkpoint} ...", flush=True)
+    actor = load_actor_from_checkpoint(args.checkpoint, args.device)
+    print("  Actor loaded.", flush=True)
+
+    print(f"Loading motion from {args.motion} ...", flush=True)
+    motion_data = load_motion_data(args.motion)
+    total_frames = get_total_frames(motion_data)
+    motion_fps = get_motion_fps(motion_data)
+    print(f"  {total_frames} frames @ {motion_fps} fps = {total_frames / motion_fps:.1f}s",
+          flush=True)
+
+    print("Loading MuJoCo model ...", flush=True)
+    mj_model = mujoco.MjModel.from_xml_path(MJCF_PATH)
+    mj_data = mujoco.MjData(mj_model)
+    mj_model.opt.timestep = SIM_DT
+
+    pelvis_id = mj_model.body("pelvis").id
+
+    # ---- RSI: pull full robot state from motion frame `init_frame` ----
+    init_frame = int(args.init_frame)
+    init_motion_state = compute_motion_state(motion_data, init_frame, motion_fps)
+    init_root_z = float(init_motion_state["root_pos_w"][2])
+    print(f"  [RSI] Initializing from motion frame {init_frame} "
+          f"(t={init_frame / motion_fps:.3f}s):", flush=True)
+    print(f"    root_pos_w     = {init_motion_state['root_pos_w']}", flush=True)
+    print(f"    root_quat_wxyz = {init_motion_state['root_quat_w_wxyz']}", flush=True)
+    print(f"    root_lin_vel_w = {init_motion_state['root_lin_vel_w']}", flush=True)
+    print(f"    root_ang_vel_w = {init_motion_state['root_ang_vel_w']}", flush=True)
+    print(f"    joint_pos_mj[:6] = {init_motion_state['joint_pos_mj'][:6]}", flush=True)
+    print(f"    joint_vel_mj[:6] = {init_motion_state['joint_vel_mj'][:6]}", flush=True)
+
+    print(f"  Default DOF (MJ order): {DEFAULT_DOF}", flush=True)
+    print(f"  Action scale (MJ order): {ACTION_SCALE}", flush=True)
+
+    prop_buf = ProprioceptionBuffer()
+    last_action_mj = np.zeros(NUM_DOFS, dtype=np.float32)
+    sim_time = float(init_frame) / motion_fps
+    step_count = 0
+    episode_count = 0
+    episode_start_step = 0
+    paused = False
+
+    def _apply_init_state():
+        """Teleport the robot to the RSI motion frame state.
+
+        Mirrors IsaacLab's ``write_joint_state_to_sim`` /
+        ``write_root_state_to_sim`` at episode reset.
+        """
+        s = init_motion_state
+        mj_data.qpos[0] = 0.0  # discard motion world XY offset
+        mj_data.qpos[1] = 0.0
+        mj_data.qpos[2] = float(s["root_pos_w"][2])
+        mj_data.qpos[3:7] = s["root_quat_w_wxyz"]
+        mj_data.qpos[7:7 + NUM_DOFS] = s["joint_pos_mj"]
+        # MuJoCo free-joint qvel convention (verified empirically; see commit msg):
+        #   qvel[0:3]  -> WORLD-frame linear velocity
+        #   qvel[3:6]  -> BODY-LOCAL-frame angular velocity (NOT world!)
+        # Motion lib stores both in world frame, so the angular component must
+        # be rotated into the body frame before writing.
+        mj_data.qvel[0:3] = s["root_lin_vel_w"]
+        mj_data.qvel[3:6] = quat_rotate_inverse(
+            s["root_quat_w_wxyz"], s["root_ang_vel_w"]
+        )
+        mj_data.qvel[6:6 + NUM_DOFS] = s["joint_vel_mj"]
+        mj_data.xfrc_applied[:] = 0
+        mujoco.mj_forward(mj_model, mj_data)
+
+    _apply_init_state()
+
+    def reset_state(reason=""):
+        nonlocal sim_time, last_action_mj, episode_count, episode_start_step
+        sim_time = float(init_frame) / motion_fps
+        last_action_mj[:] = 0
+        prop_buf.reset()
+        _apply_init_state()
+        episode_count += 1
+        episode_start_step = step_count
+        tag = f" ({reason})" if reason else ""
+        print(f"\n[reset]{tag} starting episode {episode_count}", flush=True)
+
+    def key_callback(keycode):
+        nonlocal paused
+        import glfw
+        if keycode == glfw.KEY_SPACE:
+            paused = not paused
+            print("Paused" if paused else "Resumed", flush=True)
+        elif keycode == glfw.KEY_R:
+            reset_state("manual")
+        elif keycode == glfw.KEY_V:
+            if viewer.cam.type == mujoco.mjtCamera.mjCAMERA_TRACKING:
+                viewer.cam.type = mujoco.mjtCamera.mjCAMERA_FREE
+            else:
+                viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+                viewer.cam.trackbodyid = pelvis_id
+
+    print("\n=== X2 MuJoCo Eval ===", flush=True)
+    print(f"Robot RSI-initialized from motion frame {init_frame}.", flush=True)
+    print(f"Auto-reset triggers: pelvis_z < {args.fall_height:.2f} m, "
+          f"or gravity_body[z] > {args.fall_tilt_cos:.2f} (~tilt > "
+          f"{int(np.rad2deg(np.arccos(-args.fall_tilt_cos)))}°).", flush=True)
+    if args.max_episode > 0:
+        print(f"Max episode length: {args.max_episode:.1f} s.", flush=True)
+    print("Press SPACE pause, R reset, V toggle camera.\n", flush=True)
+
+    with mujoco.viewer.launch_passive(
+        mj_model, mj_data,
+        key_callback=key_callback,
+        show_left_ui=False, show_right_ui=False,
+    ) as viewer:
+        viewer.cam.azimuth = 120
+        viewer.cam.elevation = -20
+        viewer.cam.distance = 3.0
+        viewer.cam.lookat[:] = [0.0, 0.0, init_root_z]
+        viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+        viewer.cam.trackbodyid = pelvis_id
+
+        wall_start = time.time()
+        # Motion-tracking sim_time is anchored to wall_start. Each reset
+        # rebases wall_start so real-time pacing stays smooth across episodes.
+        wall_start -= sim_time
+
+        while viewer.is_running():
+            if paused:
+                viewer.sync()
+                time.sleep(0.02)
+                continue
+
+            # -- Motion phase --
+            motion_time = sim_time * args.speed
+            motion_frame = int(motion_time * motion_fps) % total_frames
+            motion_time = motion_frame / motion_fps
+
+            # -- Read MuJoCo state --
+            qpos_j = mj_data.qpos[7:7 + NUM_DOFS].copy()
+            qvel_j = mj_data.qvel[6:6 + NUM_DOFS].copy()
+            base_quat = mj_data.qpos[3:7].copy()  # wxyz
+            # MuJoCo free-joint qvel[3:6] is in BODY-LOCAL frame (verified
+            # empirically via quaternion integration). IsaacLab's
+            # ``base_ang_vel`` proprioception term is also body-local, so we
+            # consume qvel[3:6] directly — no rotation. Previously we
+            # quat_rotate_inverse'd it under the wrong assumption that it was
+            # world-frame, which caused a double rotation and corrupted the
+            # angular-velocity history every step.
+            base_angvel = mj_data.qvel[3:6].copy()
+
+            # Convert MJ→IL using IL_TO_MJ_DOF as gather index:
+            #   result[il_pos] = source[IL_TO_MJ_DOF[il_pos]]
+            dof_pos_il = qpos_j[IL_TO_MJ_DOF]
+            dof_vel_il = qvel_j[IL_TO_MJ_DOF]
+            action_il = last_action_mj[IL_TO_MJ_DOF]
+
+            gravity = quat_rotate_inverse(base_quat, np.array([0., 0., -1.]))
+            dof_pos_rel_il = dof_pos_il - DEFAULT_DOF[IL_TO_MJ_DOF]
+
+            # -- Build observation + run policy --
+            prop_buf.append(gravity, base_angvel, dof_pos_rel_il, dof_vel_il, action_il)
+            proprioception = prop_buf.get_flat()
+            tokenizer_obs = build_tokenizer_obs(
+                motion_data, motion_time, base_quat, motion_fps)
+
+            with torch.no_grad():
+                prop_t = torch.from_numpy(proprioception).unsqueeze(0).to(args.device)
+                tok_t = torch.from_numpy(tokenizer_obs).unsqueeze(0).to(args.device)
+                action_il_t = actor(prop_t, tok_t).squeeze(0).cpu().numpy()
+
+            # Convert IL→MJ using MJ_TO_IL_DOF as gather index:
+            #   result[mj_pos] = source[MJ_TO_IL_DOF[mj_pos]]
+            action_mj = action_il_t[MJ_TO_IL_DOF]
+            last_action_mj = action_mj.copy()
+            target_pos = DEFAULT_DOF + action_mj * ACTION_SCALE
+
+            # -- PD control + step --
+            for _ in range(DECIMATION):
+                torque = KP * (target_pos - mj_data.qpos[7:7 + NUM_DOFS]) \
+                       - KD * mj_data.qvel[6:6 + NUM_DOFS]
+                for j in range(NUM_DOFS):
+                    mj_data.ctrl[JOINT_TO_ACTUATOR[j]] = torque[j]
+                mujoco.mj_step(mj_model, mj_data)
+
+            sim_time += CONTROL_DT
+            step_count += 1
+            viewer.sync()
+
+            wall_elapsed = time.time() - wall_start
+            if sim_time > wall_elapsed:
+                time.sleep(sim_time - wall_elapsed)
+
+            # -- Auto-reset on fall (IsaacLab-style termination) --
+            pelvis_z = float(mj_data.qpos[2])
+            grav_z = float(gravity[2])
+            episode_seconds = (step_count - episode_start_step) * CONTROL_DT
+            reset_reason = None
+            if pelvis_z < args.fall_height:
+                reset_reason = f"pelvis_z={pelvis_z:.3f} < {args.fall_height:.2f}"
+            elif grav_z > args.fall_tilt_cos:
+                reset_reason = (f"gravity_body[z]={grav_z:+.2f} > {args.fall_tilt_cos:.2f} "
+                                f"(tilt {int(np.rad2deg(np.arccos(np.clip(-grav_z,-1,1))))}°)")
+            elif args.max_episode > 0 and episode_seconds >= args.max_episode:
+                reset_reason = f"reached --max-episode={args.max_episode:.1f}s"
+            if reset_reason is not None:
+                print(f"  [fall] ep={episode_count} ran {episode_seconds:.2f}s, "
+                      f"reason: {reset_reason}", flush=True)
+                reset_state(reset_reason)
+                wall_start = time.time() - sim_time
+                continue
+
+            if step_count <= 5 or step_count % 250 == 0:
+                h = mj_data.qpos[2]
+                print(f"\n[ep {episode_count}] step={step_count}  sim={sim_time:.2f}s  "
+                      f"frame={motion_frame}/{total_frames}  height={h:.3f}m",
+                      flush=True)
+                print(f"  gravity_body:  {gravity}", flush=True)
+                print(f"  angvel_body:   {base_angvel}", flush=True)
+                print(f"  base_quat:     {base_quat}", flush=True)
+                print(f"  dof_pos_il[:6]: {dof_pos_il[:6]}", flush=True)
+                print(f"  dof_vel_il[:6]: {dof_vel_il[:6]}", flush=True)
+                print(f"  action_il[:6]:  {action_il_t[:6]}", flush=True)
+                print(f"  action_mj[:6]:  {action_mj[:6]}", flush=True)
+                print(f"  target_pos[:6]: {target_pos[:6]}", flush=True)
+                print(f"  action |min|={np.abs(action_il_t).min():.4f} "
+                      f"|max|={np.abs(action_il_t).max():.4f} "
+                      f"|mean|={np.abs(action_il_t).mean():.4f}", flush=True)
+                print(f"  prop shape={proprioception.shape} "
+                      f"|min|={proprioception.min():.4f} |max|={proprioception.max():.4f}",
+                      flush=True)
+                print(f"  tok  shape={tokenizer_obs.shape} "
+                      f"|min|={tokenizer_obs.min():.4f} |max|={tokenizer_obs.max():.4f}",
+                      flush=True)
+
+    print("Viewer closed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/trl/losses/token_losses.py
+++ b/gear_sonic/trl/losses/token_losses.py
@@ -48,7 +48,7 @@ def decoder_output_to_egocentric_transforms(
     decoder_output: dict,
     decoder_cfg: dict,
     humanoid: torch_humanoid_batch.Humanoid_Batch,
-    dof_converter: order_converter.G1Converter = None,
+    dof_converter: order_converter.IsaacLabMuJoCoConverter = None,
     include_extended: bool = False,
 ):
     """Convert decoder output to joint positions and 6D rotations (ortho6d).
@@ -156,7 +156,7 @@ def decoder_output_to_world_transforms(
     decoder_output: dict,
     decoder_cfg: dict,
     humanoid: torch_humanoid_batch.Humanoid_Batch,
-    dof_converter: order_converter.G1Converter = None,
+    dof_converter: order_converter.IsaacLabMuJoCoConverter = None,
     include_extended: bool = False,
 ):
     """Convert decoder output to joint positions and rotation matrices in a consistent
@@ -297,7 +297,7 @@ def _extract_dof_pos(
     decoder_output: dict,
     decoder_cfg: dict,
     humanoid: torch_humanoid_batch.Humanoid_Batch,
-    dof_converter: order_converter.G1Converter = None,
+    dof_converter: order_converter.IsaacLabMuJoCoConverter = None,
     egocentric_pos: torch.Tensor = None,
     egocentric_rot_6d: torch.Tensor = None,
 ):
@@ -1128,7 +1128,7 @@ class G1JointPositionLoss(nn.Module):
         ), f"coordinate_frame must be 'egocentric' or 'world', got '{coordinate_frame}'"
         self.coordinate_frame = coordinate_frame
         self._humanoid = create_humanoid(self._skeleton_name)
-        self._dof_converter = order_converter.G1Converter()
+        self._dof_converter = order_converter.get_converter_for_skeleton(self._skeleton_name)
         if normalize:
             num_b = (
                 self._humanoid.num_bodies_augment
@@ -1227,7 +1227,7 @@ class G1JointRotationLoss(nn.Module):
         )
         self._include_extended = include_extended
         self._humanoid = create_humanoid(self._skeleton_name)
-        self._dof_converter = order_converter.G1Converter()
+        self._dof_converter = order_converter.get_converter_for_skeleton(self._skeleton_name)
         # Normalization only makes sense for frobenius (element-wise); geodesic operates on SO(3)
         if normalize and loss_type == "frobenius":
             num_b = (
@@ -1563,7 +1563,7 @@ class G1FootContactLoss(nn.Module):
         self.contact_height_threshold = contact_height_threshold
         self.vel_threshold = vel_threshold
         self._humanoid = create_humanoid(self._skeleton_name)
-        self._dof_converter = order_converter.G1Converter()
+        self._dof_converter = order_converter.get_converter_for_skeleton(self._skeleton_name)
         self._foot_indices = [
             self._humanoid.body_names_augment.index(name) for name in self.foot_joint_names
         ]

--- a/gear_sonic/trl/utils/order_converter.py
+++ b/gear_sonic/trl/utils/order_converter.py
@@ -202,6 +202,32 @@ class H2Converter(IsaacLabMuJoCoConverter):
     FOOT_BODY_NAMES = ["left_ankle_roll_link", "right_ankle_roll_link"]
 
 
+class X2UltraConverter(IsaacLabMuJoCoConverter):
+    """Agibot X2 Ultra robot joint/body order converter between IsaacLab and MuJoCo conventions."""
+
+    def __init__(self):
+        from gear_sonic.envs.manager_env.robots.x2_ultra import (
+            X2_ULTRA_ISAACLAB_JOINTS,
+            X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY,
+            X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF,
+            X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY,
+            X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF,
+        )
+
+        self.JOINT_NAMES = X2_ULTRA_ISAACLAB_JOINTS
+        self.DOF_MAPPINGS = {
+            ("isaaclab", "mujoco"): X2_ULTRA_ISAACLAB_TO_MUJOCO_DOF,
+            ("mujoco", "isaaclab"): X2_ULTRA_MUJOCO_TO_ISAACLAB_DOF,
+        }
+        self.BODY_MAPPINGS = {
+            ("isaaclab", "mujoco"): X2_ULTRA_ISAACLAB_TO_MUJOCO_BODY,
+            ("mujoco", "isaaclab"): X2_ULTRA_MUJOCO_TO_ISAACLAB_BODY,
+        }
+
+    VR_3POINTS_BODY_NAMES = ["torso_link", "left_wrist_pitch_link", "right_wrist_pitch_link"]
+    FOOT_BODY_NAMES = ["left_ankle_roll_link", "right_ankle_roll_link"]
+
+
 def load_qpos_from_csv(csv_path: str) -> torch.Tensor:
     """Load qpos [T, D] from CSV."""
     import pandas as pd

--- a/gear_sonic/trl/utils/order_converter.py
+++ b/gear_sonic/trl/utils/order_converter.py
@@ -21,6 +21,10 @@ class IsaacLabMuJoCoConverter(ABC):
 
     ROOT_QPOS_OFFSET = 7  # root_trans(3) + root_quat(4)
     DOF_MAPPINGS: dict = {}  # Must be overridden by subclasses
+    BODY_MAPPINGS: dict = {}  # Must be overridden by subclasses
+    JOINT_NAMES: list = []
+    VR_3POINTS_BODY_NAMES: list = []
+    FOOT_BODY_NAMES: list = []
     VALID_DOF_ORDERS = ("mujoco", "isaaclab")
 
     def convert(self, data: torch.Tensor, from_order: str, to_order: str) -> torch.Tensor:
@@ -93,55 +97,15 @@ class IsaacLabMuJoCoConverter(ABC):
         """Number of actuated DOFs (excluding root)."""
         return len(self.DOF_MAPPINGS[(self.VALID_DOF_ORDERS[0], self.VALID_DOF_ORDERS[1])])
 
-
-class G1Converter(IsaacLabMuJoCoConverter):
-    """G1 ordering converter.
-
-    Imports G1 body/DOF/joint mappings from gear_sonic.envs.manager_env.robots.g1.
-    """
-
-    def __init__(self):
-        # Lazy import to avoid circular dependency:
-        # order_converter -> g1 -> mdp/__init__ -> commands -> order_converter
-        from gear_sonic.envs.manager_env.robots.g1 import (
-            G1_ISAACLAB_JOINTS,
-            G1_ISAACLAB_TO_MUJOCO_BODY,
-            G1_ISAACLAB_TO_MUJOCO_DOF,
-            G1_MUJOCO_TO_ISAACLAB_BODY,
-            G1_MUJOCO_TO_ISAACLAB_DOF,
-        )
-
-        self.JOINT_NAMES = G1_ISAACLAB_JOINTS
-        self.DOF_MAPPINGS = {
-            ("isaaclab", "mujoco"): G1_ISAACLAB_TO_MUJOCO_DOF,
-            ("mujoco", "isaaclab"): G1_MUJOCO_TO_ISAACLAB_DOF,
-        }
-        self.BODY_MAPPINGS = {
-            ("isaaclab", "mujoco"): G1_ISAACLAB_TO_MUJOCO_BODY,
-            ("mujoco", "isaaclab"): G1_MUJOCO_TO_ISAACLAB_BODY,
-        }
-
-    # Body subset names for MPJPE metrics (used by reconstruction_trainer)
-    VR_3POINTS_BODY_NAMES = ["torso_link", "left_wrist_yaw_link", "right_wrist_yaw_link"]
-    FOOT_BODY_NAMES = ["left_ankle_roll_link", "right_ankle_roll_link"]
-
     @property
     def vr_3points_mujoco_indices(self):
-        """VR 3-point body indices in full (30-body) MuJoCo body order.
-
-        These index into the full body array after isaaclab_to_mujoco_body
-        reordering, NOT the 14-body motion.yaml body_names subset.
-        """
+        """VR 3-point body indices in full MuJoCo body order."""
         mj_names = [self.JOINT_NAMES[i] for i in self.isaaclab_to_mujoco_body]
         return [mj_names.index(n) for n in self.VR_3POINTS_BODY_NAMES]
 
     @property
     def foot_mujoco_indices(self):
-        """Foot body indices in full (30-body) MuJoCo body order.
-
-        These index into the full body array after isaaclab_to_mujoco_body
-        reordering, NOT the 14-body motion.yaml body_names subset.
-        """
+        """Foot body indices in full MuJoCo body order."""
         mj_names = [self.JOINT_NAMES[i] for i in self.isaaclab_to_mujoco_body]
         return [mj_names.index(n) for n in self.FOOT_BODY_NAMES]
 
@@ -173,6 +137,35 @@ class G1Converter(IsaacLabMuJoCoConverter):
             "mujoco_to_isaaclab_dof": self.mujoco_to_isaaclab_dof,
             "isaaclab_to_mujoco_body": self.isaaclab_to_mujoco_body,
             "mujoco_to_isaaclab_body": self.mujoco_to_isaaclab_body,
+        }
+
+
+class G1Converter(IsaacLabMuJoCoConverter):
+    """G1 ordering converter.
+
+    Imports G1 body/DOF/joint mappings from gear_sonic.envs.manager_env.robots.g1.
+    """
+
+    VR_3POINTS_BODY_NAMES = ["torso_link", "left_wrist_yaw_link", "right_wrist_yaw_link"]
+    FOOT_BODY_NAMES = ["left_ankle_roll_link", "right_ankle_roll_link"]
+
+    def __init__(self):
+        from gear_sonic.envs.manager_env.robots.g1 import (
+            G1_ISAACLAB_JOINTS,
+            G1_ISAACLAB_TO_MUJOCO_BODY,
+            G1_ISAACLAB_TO_MUJOCO_DOF,
+            G1_MUJOCO_TO_ISAACLAB_BODY,
+            G1_MUJOCO_TO_ISAACLAB_DOF,
+        )
+
+        self.JOINT_NAMES = G1_ISAACLAB_JOINTS
+        self.DOF_MAPPINGS = {
+            ("isaaclab", "mujoco"): G1_ISAACLAB_TO_MUJOCO_DOF,
+            ("mujoco", "isaaclab"): G1_MUJOCO_TO_ISAACLAB_DOF,
+        }
+        self.BODY_MAPPINGS = {
+            ("isaaclab", "mujoco"): G1_ISAACLAB_TO_MUJOCO_BODY,
+            ("mujoco", "isaaclab"): G1_MUJOCO_TO_ISAACLAB_BODY,
         }
 
 
@@ -226,6 +219,56 @@ class X2UltraConverter(IsaacLabMuJoCoConverter):
 
     VR_3POINTS_BODY_NAMES = ["torso_link", "left_wrist_pitch_link", "right_wrist_pitch_link"]
     FOOT_BODY_NAMES = ["left_ankle_roll_link", "right_ankle_roll_link"]
+
+
+_CONVERTER_REGISTRY = {
+    "g1": G1Converter,
+    "g1_model_12_dex": G1Converter,
+    "h2": H2Converter,
+    "x2_ultra": X2UltraConverter,
+}
+
+_SKELETON_TO_ROBOT = {
+    "motion_g1_extended_toe": "g1",
+    "motion_g1": "g1",
+    "motion_h2": "h2",
+    "motion_x2_ultra": "x2_ultra",
+    "motion_x2_ultra_extended_toe": "x2_ultra",
+    "motion": "g1",
+}
+
+
+def get_converter(robot_type: str = "g1") -> IsaacLabMuJoCoConverter:
+    """Get the order converter for a given robot type."""
+    cls = _CONVERTER_REGISTRY.get(robot_type)
+    if cls is None:
+        raise ValueError(
+            f"Unknown robot type '{robot_type}'. Available: {list(_CONVERTER_REGISTRY.keys())}"
+        )
+    return cls()
+
+
+def get_converter_for_skeleton(skeleton_name: str) -> IsaacLabMuJoCoConverter:
+    """Infer the correct order converter from a skeleton config name."""
+    robot_type = _SKELETON_TO_ROBOT.get(skeleton_name)
+    if robot_type is None:
+        for key, val in _SKELETON_TO_ROBOT.items():
+            if key in skeleton_name:
+                robot_type = val
+                break
+    if robot_type is None:
+        robot_type = "g1"
+    return get_converter(robot_type)
+
+
+def get_converter_for_mjcf(asset_filename: str) -> IsaacLabMuJoCoConverter:
+    """Infer the correct order converter from an MJCF asset filename."""
+    fname = asset_filename.lower()
+    if "x2_ultra" in fname or "x2t" in fname:
+        return X2UltraConverter()
+    elif "h2" in fname:
+        return H2Converter()
+    return G1Converter()
 
 
 def load_qpos_from_csv(csv_path: str) -> torch.Tensor:

--- a/gear_sonic/utils/motion_lib/motion_lib_base.py
+++ b/gear_sonic/utils/motion_lib/motion_lib_base.py
@@ -2126,13 +2126,12 @@ class MotionLibBase:
                 if self.has_action:
                     curr_motion.action = to_torch(curr_file["action"]).clone()[start:end]
 
-                # Extract hand DOFs if motion file has more than 29 DOFs
                 hand_dof_count = self.m_cfg.get("hand_dof_count", 0)
                 if hand_dof_count > 0 and "dof" in curr_file:
                     raw_dof = to_torch(curr_file["dof"]).clone()[start:end]
-                    if raw_dof.shape[-1] > 29:
-                        # Extract hand DOFs (indices 29 onwards) and interpolate to target FPS
-                        hand_dof = raw_dof[:, 29 : 29 + hand_dof_count]
+                    base_dof = self.humanoid.num_dof
+                    if raw_dof.shape[-1] > base_dof:
+                        hand_dof = raw_dof[:, base_dof : base_dof + hand_dof_count]
                         if curr_file["fps"] != self.target_fps:
                             # Simple linear interpolation for hand DOFs
                             num_target_frames = curr_motion["dof_pos"].shape[0]


### PR DESCRIPTION
## Add Agibot X2 Ultra (31 DOF) Embodiment to GEAR-SONIC

This PR integrates the **Agibot X2 Ultra** humanoid (31 DOF) into the GEAR-SONIC whole-body control pipeline, covering the full path from robot description to SONIC training to MuJoCo sim-to-sim deployment.

### What's included

**Robot description**
- URDF, MJCF, and STL meshes for the X2 Ultra under `robot_description/`
- Robot config (`x2_ultra.py`) with actuator groups, joint limits from vendor specs, and IsaacLab/MuJoCo index mappings (round-trip verified)
- `X2UltraConverter` in `order_converter.py` for joint-order translation between URDF, IsaacLab, and MuJoCo conventions

**SONIC training pipeline**
- Generalized the codebase beyond Unitree G1 (29 DOF) to support arbitrary DOF counts
- Refactored `convert_soma_csv_to_motion_lib.py` with `--robot` flag and per-robot DOF axis/joint constants
- Added factory functions (`get_converter_for_skeleton`, `get_converter_for_mjcf`) to `order_converter.py`; replaced hardcoded G1 DOF checks with dynamic `num_dof`
- X2 experiment configs: full training (`sonic_x2_ultra.yaml`), smoke test (`sonic_x2_ultra_smoke.yaml`), tokenizer, actor-critic, and aux loss configs

**Joint ordering fix**
- Fixed IsaacLab's alphabetical BFS traversal ordering -- `head_yaw_link` ("h") precedes `left/right_shoulder_pitch_link` ("l"/"r") at the same depth. The previous mapping assumed URDF XML order, causing head and shoulder DOFs to be cross-contaminated.
- Documented the alphabetical BFS pitfall in `conventions.md` and `new_embodiments.md`

**MuJoCo sim-to-sim deployment**
- `eval_x2_mujoco.py` -- runs a trained SONIC checkpoint in MuJoCo with Reference State Initialization, IsaacLab-faithful proprioception, FSQ quantization, and auto-reset on fall
- `dump_isaaclab_step0.py` -- captures IsaacLab's step-0 obs/encoder/FSQ/decoder/action for side-by-side debugging
- Fixed a critical sim-to-sim bug: MuJoCo free-joint `qvel[3:6]` is body-local (not world), which was silently double-rotating angular velocity and corrupting proprioception every step
- `docs/source/user_guide/sim2sim_mujoco.md` -- documents 10 IsaacLab-vs-MuJoCo gotchas with symptoms, debugging recipes, and a symptom-to-cause table


### Sim-to-sim deployment guide

Added `docs/source/user_guide/sim2sim_mujoco.md` -- a comprehensive guide for deploying trained SONIC checkpoints from IsaacLab to MuJoCo. Documents 10 IsaacLab-vs-MuJoCo gotchas discovered during this bring-up, 8 of which correspond to real bugs fixed in the code. Includes a symptom-to-cause lookup table and a step-by-step debugging recipe using `dump_isaaclab_step0.py`.

### Results

| IsaacLab | MuJoCo (sim-to-sim) |
|:---:|:---:|
| <img width="480" alt="X2 Ultra walking in IsaacLab" src="https://github.com/user-attachments/assets/6f67a02e-2dc8-40db-b157-503d1a2e3980" /> | <img width="340" alt="X2 Ultra walking in MuJoCo" src="https://github.com/user-attachments/assets/71e12225-2ffd-45d0-8755-be78d6568734" /> |