### PR TITLE
fix(g1_env): restore gravity compensation feedforward

### DIFF
--- a/decoupled_wbc/control/envs/g1/g1_env.py
+++ b/decoupled_wbc/control/envs/g1/g1_env.py
@@ -44,7 +44,7 @@ class G1Env(HumanoidEnv):
 
         # Gravity compensation settings
         self.enable_gravity_compensation = config.get("enable_gravity_compensation", False)
-        self.gravity_compensation_joints = config.get("gravity_compensation_joints", ["arms"])
+        self.gravity_compensation_joints = config.get("gravity_compensation_joints") or ["arms"]
 
         if self.enable_gravity_compensation:
             print(
@@ -221,12 +221,19 @@ class G1Env(HumanoidEnv):
 
         # Map action from joint order to actuator order
         body_actuator_q = self.robot_model.get_body_actuated_joints(action["q"])
+        body_tau = np.zeros_like(body_actuator_q)
+        if self.enable_gravity_compensation and self.last_obs is not None:
+            gravity_torques = self.robot_model.compute_gravity_compensation_torques(
+                self.last_obs["q"],
+                joint_groups=self.gravity_compensation_joints,
+            )
+            body_tau = self.robot_model.get_body_actuated_joints(gravity_torques)
 
         self.body().queue_action(
             {
                 "body_q": body_actuator_q,
                 "body_dq": np.zeros_like(body_actuator_q),
-                "body_tau": np.zeros_like(body_actuator_q),
+                "body_tau": body_tau,
             }
         )
 

--- a/decoupled_wbc/control/main/teleop/configs/configs.py
+++ b/decoupled_wbc/control/main/teleop/configs/configs.py
@@ -29,6 +29,10 @@ def override_wbc_config(
         KeyError: If any required keys are missing from the WBC YAML configuration
                   (only when missed_keys_only=False)
     """
+    gravity_compensation_joints = config.gravity_compensation_joints
+    if config.enable_gravity_compensation and gravity_compensation_joints is None:
+        gravity_compensation_joints = ["arms"]
+
     # Override yaml values with dataclass values
     key_to_value = {
         "INTERFACE": config.interface,
@@ -46,7 +50,7 @@ def override_wbc_config(
         "upper_body_max_joint_speed": config.upper_body_joint_speed,
         "keyboard_dispatcher_type": config.keyboard_dispatcher_type,
         "enable_gravity_compensation": config.enable_gravity_compensation,
-        "gravity_compensation_joints": config.gravity_compensation_joints,
+        "gravity_compensation_joints": gravity_compensation_joints,
         "high_elbow_pose": config.high_elbow_pose,
     }
 
@@ -141,7 +145,8 @@ class BaseConfig(ArgsConfigTemplate):
     """Enable gravity compensation using pinocchio dynamics."""
 
     gravity_compensation_joints: Optional[list[str]] = None
-    """Joint groups to apply gravity compensation to (e.g., ['arms', 'left_arm', 'right_arm'])."""
+    """Joint groups to apply gravity compensation to (e.g., ['arms', 'left_arm', 'right_arm']).
+    Defaults to ['arms'] when enable_gravity_compensation is True and this is None."""
     # Teleop/Device Configuration
     body_control_device: str = "dummy"
     """Device to use for body control. Options: dummy, vive, iphone, leapmotion, joycon."""

--- a/decoupled_wbc/tests/sim/test_g1_env.py
+++ b/decoupled_wbc/tests/sim/test_g1_env.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+import sys
+import types
+
+from decoupled_wbc.control.main.teleop.configs.configs import ControlLoopConfig
+from decoupled_wbc.control.robot_model.instantiation.g1 import instantiate_g1_robot_model
+import numpy as np
+
+
+def _install_ros_stubs() -> None:
+    if "rclpy" in sys.modules:
+        return
+
+    rclpy = types.ModuleType("rclpy")
+    rclpy.ok = lambda: False
+    rclpy.init = lambda *args, **kwargs: None
+    rclpy.create_node = lambda *args, **kwargs: None
+    rclpy.spin = lambda *args, **kwargs: None
+    rclpy.get_global_executor = lambda: types.SimpleNamespace(get_nodes=lambda: [])
+    rclpy.shutdown = lambda *args, **kwargs: None
+    rclpy.exceptions = types.SimpleNamespace(ROSInterruptException=Exception)
+
+    rclpy_executors = types.ModuleType("rclpy.executors")
+    rclpy_executors.SingleThreadedExecutor = object
+
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = object
+
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.Image = object
+    sensor_msgs.msg = sensor_msgs_msg
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.ByteMultiArray = object
+    std_msgs.msg = std_msgs_msg
+
+    std_srvs = types.ModuleType("std_srvs")
+    std_srvs_srv = types.ModuleType("std_srvs.srv")
+    std_srvs_srv.Trigger = object
+    std_srvs.srv = std_srvs_srv
+
+    sys.modules["rclpy"] = rclpy
+    sys.modules["rclpy.executors"] = rclpy_executors
+    sys.modules["rclpy.node"] = rclpy_node
+    sys.modules["sensor_msgs"] = sensor_msgs
+    sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
+    sys.modules["std_msgs"] = std_msgs
+    sys.modules["std_msgs.msg"] = std_msgs_msg
+    sys.modules["std_srvs"] = std_srvs
+    sys.modules["std_srvs.srv"] = std_srvs_srv
+
+
+_install_ros_stubs()
+
+from decoupled_wbc.control.envs.g1.g1_env import G1Env
+
+
+class TestG1EnvGravityCompensation:
+    def test_queue_action_applies_gravity_compensation_when_enabled(self):
+        robot_model = instantiate_g1_robot_model(waist_location="lower_body")
+
+        env = object.__new__(G1Env)
+        env.robot_model = robot_model
+        env.enable_gravity_compensation = True
+        env.gravity_compensation_joints = ["arms"]
+        env.with_hands = False
+
+        arm_indices = robot_model.get_joint_group_indices("arms")
+        q = np.zeros(robot_model.num_dofs)
+        for idx in arm_indices:
+            q[idx] = 0.3
+        env.last_obs = {"q": q}
+
+        mock_safety = MagicMock()
+        mock_safety.handle_violations = lambda obs, action: {"action": action}
+        env.safety_monitor = mock_safety
+
+        captured_actions = []
+        mock_body = MagicMock()
+        mock_body.queue_action = lambda a: captured_actions.append(a)
+        env.body = lambda: mock_body
+
+        env.queue_action({"q": np.zeros(robot_model.num_dofs)})
+
+        assert len(captured_actions) == 1
+        body_tau = captured_actions[0]["body_tau"]
+        assert not np.allclose(body_tau, 0)
+
+    def test_queue_action_keeps_zero_torques_when_gravity_compensation_disabled(self):
+        robot_model = instantiate_g1_robot_model(waist_location="lower_body")
+
+        env = object.__new__(G1Env)
+        env.robot_model = robot_model
+        env.enable_gravity_compensation = False
+        env.gravity_compensation_joints = ["arms"]
+        env.with_hands = False
+
+        arm_indices = robot_model.get_joint_group_indices("arms")
+        q = np.zeros(robot_model.num_dofs)
+        for idx in arm_indices:
+            q[idx] = 0.3
+        env.last_obs = {"q": q}
+
+        mock_safety = MagicMock()
+        mock_safety.handle_violations = lambda obs, action: {"action": action}
+        env.safety_monitor = mock_safety
+
+        captured_actions = []
+        mock_body = MagicMock()
+        mock_body.queue_action = lambda a: captured_actions.append(a)
+        env.body = lambda: mock_body
+
+        env.queue_action({"q": np.zeros(robot_model.num_dofs)})
+
+        assert len(captured_actions) == 1
+        body_tau = captured_actions[0]["body_tau"]
+        assert np.allclose(body_tau, 0)
+
+
+def test_control_loop_config_defaults_gravity_compensation_joints_to_arms():
+    config = ControlLoopConfig(
+        interface="sim",
+        enable_gravity_compensation=True,
+        gravity_compensation_joints=None,
+    )
+
+    wbc_config = config.load_wbc_yaml()
+
+    assert wbc_config["gravity_compensation_joints"] == ["arms"]


### PR DESCRIPTION
## Summary

This refreshes the gravity-compensation fix from the earlier closed PR #20, but with a clearer reproduction path and explicit regression coverage.

The root issue is that `G1Env.queue_action()` always sends `body_tau = 0`, even when `enable_gravity_compensation` is enabled. In practice this makes the flag ineffective in the active G1 control-loop path.

On our side this showed up most clearly in the grasp pipeline: when running the normal G1 controller + planner flow with gravity compensation enabled, pressing `H` to return home would let the upper body sag/drop first and only then recover toward the home pose. Restoring gravity feedforward brings that path back to normal.

## Changes

- restore gravity-compensation feedforward in `decoupled_wbc/control/envs/g1/g1_env.py`
  - compute gravity torques from the latest observed joint state
  - map them into actuator order
  - send them through `body_tau` instead of always sending zeros
- normalize the control-loop default for `gravity_compensation_joints`
  - when gravity compensation is enabled and no explicit joint list is provided, keep the intended default as `['arms']`
  - this avoids passing an explicit `None` through the config path and silently changing the compensation scope
- add focused regression tests for both behaviors
  - `queue_action()` produces nonzero torques when gravity compensation is enabled
  - `queue_action()` keeps zero torques when gravity compensation is disabled
  - control-loop config defaulting preserves `['arms']`

## Why this is safe

- the torque path is still gated behind `enable_gravity_compensation`
- when the flag is off, behavior stays unchanged
- the joint-group default matches the existing documented/operator expectation for G1 upper-body compensation
- the change is covered by small unit tests rather than only by end-to-end grasp behavior

## Testing

Locally verified with:

```bash
PYTHONPATH=submodules/gr00t-wbc uv run python -m pytest submodules/gr00t-wbc/decoupled_wbc/tests/sim/test_g1_env.py -q
```

## Context

PR #20 already identified the missing gravity-torque application, but that branch was later discarded and is now conflicting. This PR supersedes that change with refreshed context, a slightly stronger config fix, and explicit regression tests.
