### PR TITLE
[codex] Add Inspire hand MuJoCo model

### DIFF
--- a/gear_sonic/data/robot_model/model_data/g1/g1_29dof_with_inspire_hand.xml
+++ b/gear_sonic/data/robot_model/model_data/g1/g1_29dof_with_inspire_hand.xml
@@ -1,0 +1,727 @@
+<mujoco model="g1_29dof_with_inspire_hand">
+  <compiler angle="radian" meshdir="meshes" />
+  <default>
+    <default class="torso_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.2" />
+    </default>
+    <default class="leg_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.2" />
+    </default>
+    <default class="ankle_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.2" />
+    </default>
+    <default class="arm_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.2" />
+    </default>
+    <default class="wrist_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.1" />
+    </default>
+    <default class="finger_motor">
+      <joint damping="0.05" armature="0.01" frictionloss="0.1" />
+    </default>
+  </default>
+  <asset>
+    <mesh name="pelvis" file="pelvis.STL" />
+    <mesh name="pelvis_contour_link" file="pelvis_contour_link.STL" />
+    <mesh name="left_hip_pitch_link" file="left_hip_pitch_link.STL" />
+    <mesh name="left_hip_roll_link" file="left_hip_roll_link.STL" />
+    <mesh name="left_hip_yaw_link" file="left_hip_yaw_link.STL" />
+    <mesh name="left_knee_link" file="left_knee_link.STL" />
+    <mesh name="left_ankle_pitch_link" file="left_ankle_pitch_link.STL" />
+    <mesh name="left_ankle_roll_link" file="left_ankle_roll_link.STL" />
+    <mesh name="right_hip_pitch_link" file="right_hip_pitch_link.STL" />
+    <mesh name="right_hip_roll_link" file="right_hip_roll_link.STL" />
+    <mesh name="right_hip_yaw_link" file="right_hip_yaw_link.STL" />
+    <mesh name="right_knee_link" file="right_knee_link.STL" />
+    <mesh name="right_ankle_pitch_link" file="right_ankle_pitch_link.STL" />
+    <mesh name="right_ankle_roll_link" file="right_ankle_roll_link.STL" />
+    <mesh name="waist_yaw_link" file="waist_yaw_link.STL" />
+    <mesh name="waist_roll_link" file="waist_roll_link.STL" />
+    <mesh name="torso_link" file="torso_link.STL" />
+    <mesh name="logo_link" file="logo_link.STL" />
+    <mesh name="head_link" file="head_link.STL" />
+    <mesh name="waist_support_link" file="waist_support_link.STL" />
+    <mesh name="left_shoulder_pitch_link" file="left_shoulder_pitch_link.STL" />
+    <mesh name="left_shoulder_roll_link" file="left_shoulder_roll_link.STL" />
+    <mesh name="left_shoulder_yaw_link" file="left_shoulder_yaw_link.STL" />
+    <mesh name="left_elbow_link" file="left_elbow_link.STL" />
+    <mesh name="left_wrist_roll_link" file="left_wrist_roll_link.STL" />
+    <mesh name="left_wrist_pitch_link" file="left_wrist_pitch_link.STL" />
+    <mesh name="left_wrist_yaw_link" file="left_wrist_yaw_link.STL" />
+    <mesh name="left_hand_palm_link" file="left_hand_palm_link.STL" />
+    <mesh name="left_hand_thumb_0_link" file="left_hand_thumb_0_link.STL" />
+    <mesh name="left_hand_thumb_1_link" file="left_hand_thumb_1_link.STL" />
+    <mesh name="left_hand_thumb_2_link" file="left_hand_thumb_2_link.STL" />
+    <mesh name="left_hand_middle_0_link" file="left_hand_middle_0_link.STL" />
+    <mesh name="left_hand_middle_1_link" file="left_hand_middle_1_link.STL" />
+    <mesh name="left_hand_index_0_link" file="left_hand_index_0_link.STL" />
+    <mesh name="left_hand_index_1_link" file="left_hand_index_1_link.STL" />
+    <mesh name="right_shoulder_pitch_link" file="right_shoulder_pitch_link.STL" />
+    <mesh name="right_shoulder_roll_link" file="right_shoulder_roll_link.STL" />
+    <mesh name="right_shoulder_yaw_link" file="right_shoulder_yaw_link.STL" />
+    <mesh name="right_elbow_link" file="right_elbow_link.STL" />
+    <mesh name="right_wrist_roll_link" file="right_wrist_roll_link.STL" />
+    <mesh name="right_wrist_pitch_link" file="right_wrist_pitch_link.STL" />
+    <mesh name="right_wrist_yaw_link" file="right_wrist_yaw_link.STL" />
+    <mesh name="right_hand_palm_link" file="right_hand_palm_link.STL" />
+    <mesh name="right_hand_thumb_0_link" file="right_hand_thumb_0_link.STL" />
+    <mesh name="right_hand_thumb_1_link" file="right_hand_thumb_1_link.STL" />
+    <mesh name="right_hand_thumb_2_link" file="right_hand_thumb_2_link.STL" />
+    <mesh name="right_hand_middle_0_link" file="right_hand_middle_0_link.STL" />
+    <mesh name="right_hand_middle_1_link" file="right_hand_middle_1_link.STL" />
+    <mesh name="right_hand_index_0_link" file="right_hand_index_0_link.STL" />
+    <mesh name="right_hand_index_1_link" file="right_hand_index_1_link.STL" />
+    <mesh name="inspire_L_hand_base_link" file="inspire_hand/L_hand_base_link.STL" />
+    <mesh name="inspire_R_hand_base_link" file="inspire_hand/R_hand_base_link.STL" />
+    <mesh name="inspire_Link11_L" file="inspire_hand/Link11_L.STL" />
+    <mesh name="inspire_Link12_L" file="inspire_hand/Link12_L.STL" />
+    <mesh name="inspire_Link13_L" file="inspire_hand/Link13_L.STL" />
+    <mesh name="inspire_Link14_L" file="inspire_hand/Link14_L.STL" />
+    <mesh name="inspire_Link15_L" file="inspire_hand/Link15_L.STL" />
+    <mesh name="inspire_Link16_L" file="inspire_hand/Link16_L.STL" />
+    <mesh name="inspire_Link17_L" file="inspire_hand/Link17_L.STL" />
+    <mesh name="inspire_Link18_L" file="inspire_hand/Link18_L.STL" />
+    <mesh name="inspire_Link19_L" file="inspire_hand/Link19_L.STL" />
+    <mesh name="inspire_Link20_L" file="inspire_hand/Link20_L.STL" />
+    <mesh name="inspire_Link21_L" file="inspire_hand/Link21_L.STL" />
+    <mesh name="inspire_Link22_L" file="inspire_hand/Link22_L.STL" />
+    <mesh name="inspire_Link11_R" file="inspire_hand/Link11_R.STL" />
+    <mesh name="inspire_Link12_R" file="inspire_hand/Link12_R.STL" />
+    <mesh name="inspire_Link13_R" file="inspire_hand/Link13_R.STL" />
+    <mesh name="inspire_Link14_R" file="inspire_hand/Link14_R.STL" />
+    <mesh name="inspire_Link15_R" file="inspire_hand/Link15_R.STL" />
+    <mesh name="inspire_Link16_R" file="inspire_hand/Link16_R.STL" />
+    <mesh name="inspire_Link17_R" file="inspire_hand/Link17_R.STL" />
+    <mesh name="inspire_Link18_R" file="inspire_hand/Link18_R.STL" />
+    <mesh name="inspire_Link19_R" file="inspire_hand/Link19_R.STL" />
+    <mesh name="inspire_Link20_R" file="inspire_hand/Link20_R.STL" />
+    <mesh name="inspire_Link21_R" file="inspire_hand/Link21_R.STL" />
+    <mesh name="inspire_Link22_R" file="inspire_hand/Link22_R.STL" />
+  </asset>
+  <worldbody>
+    <body name="pelvis" pos="0 0 0.793">
+      <inertial pos="0 0 -0.07605" quat="1 0 -0.000399148 0" mass="3.813" diaginertia="0.010549 0.0093089 0.0079184" />
+      <joint name="floating_base_joint" type="free" limited="false" actuatorfrclimited="false" />
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="pelvis" />
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="pelvis_contour_link" />
+      <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="pelvis_contour_link" />
+      <body name="left_hip_pitch_link" pos="0 0.064452 -0.1027">
+        <inertial pos="0.002741 0.047791 -0.02606" quat="0.954862 0.293964 0.0302556 0.030122" mass="1.35" diaginertia="0.00181517 0.00153422 0.00116212" />
+        <joint name="left_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.5307 2.8798" actuatorfrcrange="-88 88" class="leg_motor" />
+        <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="left_hip_pitch_link" />
+        <geom type="mesh" rgba="0.2 0.2 0.2 1" mesh="left_hip_pitch_link" />
+        <body name="left_hip_roll_link" pos="0 0.052 -0.030465" quat="0.996179 0 -0.0873386 0">
+          <inertial pos="0.029812 -0.001045 -0.087934" quat="0.977808 -1.97119e-05 0.205576 -0.0403793" mass="1.52" diaginertia="0.00254986 0.00241169 0.00148755" />
+          <joint name="left_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.5236 2.9671" actuatorfrcrange="-88 88" class="leg_motor" />
+          <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_hip_roll_link" />
+          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_hip_roll_link" />
+          <body name="left_hip_yaw_link" pos="0.025001 0 -0.12412">
+            <inertial pos="-0.057709 -0.010981 -0.15078" quat="0.600598 0.15832 0.223482 0.751181" mass="1.702" diaginertia="0.00776166 0.00717575 0.00160139" />
+            <joint name="left_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.7576 2.7576" actuatorfrcrange="-88 88" class="leg_motor" />
+            <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_hip_yaw_link" />
+            <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_hip_yaw_link" />
+            <body name="left_knee_link" pos="-0.078273 0.0021489 -0.17734" quat="0.996179 0 0.0873386 0">
+              <inertial pos="0.005457 0.003964 -0.12074" quat="0.923418 -0.0327699 0.0158246 0.382067" mass="1.932" diaginertia="0.0113804 0.0112778 0.00146458" />
+              <joint name="left_knee_joint" pos="0 0 0" axis="0 1 0" range="-0.087267 2.8798" actuatorfrcrange="-139 139" class="leg_motor" />
+              <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_knee_link" />
+              <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_knee_link" />
+              <body name="left_ankle_pitch_link" pos="0 -9.4445e-05 -0.30001">
+                <inertial pos="-0.007269 0 0.011137" quat="0.603053 0.369225 0.369225 0.603053" mass="0.074" diaginertia="1.89e-05 1.40805e-05 6.9195e-06" />
+                <joint name="left_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.87267 0.5236" actuatorfrcrange="-50 50" class="ankle_motor" />
+                <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_ankle_pitch_link" />
+                <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_ankle_pitch_link" />
+                <body name="left_ankle_roll_link" pos="0 0 -0.017558">
+                  <inertial pos="0.026505 0 -0.016425" quat="-0.000481092 0.728482 -0.000618967 0.685065" mass="0.608" diaginertia="0.00167218 0.0016161 0.000217621" />
+                  <joint name="left_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.2618 0.2618" actuatorfrcrange="-50 50" class="ankle_motor" />
+                  <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="left_ankle_roll_link" />
+                  <geom size="0.005" pos="-0.05 0.025 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="-0.05 -0.025 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="0.12 0.03 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="0.12 -0.03 -0.03" rgba="0.2 0.2 0.2 1" />
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="right_hip_pitch_link" pos="0 -0.064452 -0.1027">
+        <inertial pos="0.002741 -0.047791 -0.02606" quat="0.954862 -0.293964 0.0302556 -0.030122" mass="1.35" diaginertia="0.00181517 0.00153422 0.00116212" />
+        <joint name="right_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.5307 2.8798" actuatorfrcrange="-88 88" class="leg_motor" />
+        <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="right_hip_pitch_link" />
+        <geom type="mesh" rgba="0.2 0.2 0.2 1" mesh="right_hip_pitch_link" />
+        <body name="right_hip_roll_link" pos="0 -0.052 -0.030465" quat="0.996179 0 -0.0873386 0">
+          <inertial pos="0.029812 0.001045 -0.087934" quat="0.977808 1.97119e-05 0.205576 0.0403793" mass="1.52" diaginertia="0.00254986 0.00241169 0.00148755" />
+          <joint name="right_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.9671 0.5236" actuatorfrcrange="-88 88" class="leg_motor" />
+          <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_hip_roll_link" />
+          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_hip_roll_link" />
+          <body name="right_hip_yaw_link" pos="0.025001 0 -0.12412">
+            <inertial pos="-0.057709 0.010981 -0.15078" quat="0.751181 0.223482 0.15832 0.600598" mass="1.702" diaginertia="0.00776166 0.00717575 0.00160139" />
+            <joint name="right_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.7576 2.7576" actuatorfrcrange="-88 88" class="leg_motor" />
+            <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_hip_yaw_link" />
+            <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_hip_yaw_link" />
+            <body name="right_knee_link" pos="-0.078273 -0.0021489 -0.17734" quat="0.996179 0 0.0873386 0">
+              <inertial pos="0.005457 -0.003964 -0.12074" quat="0.923439 0.0345276 0.0116333 -0.382012" mass="1.932" diaginertia="0.011374 0.0112843 0.00146452" />
+              <joint name="right_knee_joint" pos="0 0 0" axis="0 1 0" range="-0.087267 2.8798" actuatorfrcrange="-139 139" class="leg_motor" />
+              <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_knee_link" />
+              <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_knee_link" />
+              <body name="right_ankle_pitch_link" pos="0 9.4445e-05 -0.30001">
+                <inertial pos="-0.007269 0 0.011137" quat="0.603053 0.369225 0.369225 0.603053" mass="0.074" diaginertia="1.89e-05 1.40805e-05 6.9195e-06" />
+                <joint name="right_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.87267 0.5236" actuatorfrcrange="-50 50" class="ankle_motor" />
+                <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_ankle_pitch_link" />
+                <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_ankle_pitch_link" />
+                <body name="right_ankle_roll_link" pos="0 0 -0.017558">
+                  <inertial pos="0.026505 0 -0.016425" quat="0.000481092 0.728482 0.000618967 0.685065" mass="0.608" diaginertia="0.00167218 0.0016161 0.000217621" />
+                  <joint name="right_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.2618 0.2618" actuatorfrcrange="-50 50" class="ankle_motor" />
+                  <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="right_ankle_roll_link" />
+                  <geom size="0.005" pos="-0.05 0.025 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="-0.05 -0.025 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="0.12 0.03 -0.03" rgba="0.2 0.2 0.2 1" />
+                  <geom size="0.005" pos="0.12 -0.03 -0.03" rgba="0.2 0.2 0.2 1" />
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="waist_yaw_link">
+        <inertial pos="0.003964 0 0.018769" quat="-0.0178291 0.628464 0.0282471 0.777121" mass="0.244" diaginertia="0.000158561 0.000124229 9.67669e-05" />
+        <joint name="waist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.618 2.618" actuatorfrcrange="-88 88" class="torso_motor" />
+        <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="waist_yaw_link" />
+        <body name="waist_roll_link" pos="-0.0039635 0 0.035">
+          <inertial pos="0 -0.000236 0.010111" quat="0.99979 0.020492 0 0" mass="0.047" diaginertia="7.515e-06 6.40206e-06 3.98394e-06" />
+          <joint name="waist_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.52 0.52" actuatorfrcrange="-50 50" class="torso_motor" />
+          <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="waist_roll_link" />
+          <body name="torso_link" pos="0 0 0.019">
+            <camera name="head_camera" pos="0.06 0.0 0.45" euler="0 -0.8 -1.57" />
+            <inertial pos="0.00331658 0.000261533 0.179856" quat="0.999831 0.000376204 0.0179895 -0.00377704" mass="9.598" diaginertia="0.12407 0.111951 0.0325382" />
+            <joint name="waist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.52 0.52" actuatorfrcrange="-50 50" class="torso_motor" />
+            <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="torso_link" />
+            <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="torso_link" />
+            <geom pos="0.0039635 0 -0.054" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="logo_link" />
+            <geom pos="0.0039635 0 -0.054" quat="1 0 0 0" type="mesh" rgba="0.2 0.2 0.2 1" mesh="logo_link" />
+            <geom pos="0.0039635 0 -0.054" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="head_link" />
+            <geom pos="0.0039635 0 -0.054" type="mesh" rgba="0.2 0.2 0.2 1" mesh="head_link" />
+            <geom pos="0.0039635 0 -0.054" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="waist_support_link" />
+            <geom pos="0.0039635 0 -0.054" quat="1 0 0 0" type="mesh" rgba="0.7 0.7 0.7 1" mesh="waist_support_link" />
+            <site name="imu" size="0.01" pos="-0.03959 -0.00224 0.13792" />
+            <body name="left_shoulder_pitch_link" pos="0.0039563 0.10022 0.23778" quat="0.990264 0.139201 1.38722e-05 -9.86868e-05">
+              <inertial pos="0 0.035892 -0.011628" quat="0.654152 0.0130458 -0.326267 0.68225" mass="0.718" diaginertia="0.000465864 0.000432842 0.000406394" />
+              <joint name="left_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.0892 2.6704" actuatorfrcrange="-25 25" class="arm_motor" />
+              <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_shoulder_pitch_link" />
+              <geom size="0.03 0.025" pos="0 0.04 -0.01" quat="0.707107 0 0.707107 0" type="cylinder" rgba="0.7 0.7 0.7 1" />
+              <body name="left_shoulder_roll_link" pos="0 0.038 -0.013831" quat="0.990268 -0.139172 0 0">
+                <inertial pos="-0.000227 0.00727 -0.063243" quat="0.701256 -0.0196223 -0.00710317 0.712604" mass="0.643" diaginertia="0.000691311 0.000618011 0.000388977" />
+                <joint name="left_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-1.5882 2.2515" actuatorfrcrange="-25 25" class="arm_motor" />
+                <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_shoulder_roll_link" />
+                <geom size="0.03 0.015" pos="-0.004 0.006 -0.053" type="cylinder" rgba="0.7 0.7 0.7 1" />
+                <body name="left_shoulder_yaw_link" pos="0 0.00624 -0.1032">
+                  <inertial pos="0.010773 -0.002949 -0.072009" quat="0.716879 -0.0964829 -0.0679942 0.687134" mass="0.734" diaginertia="0.00106187 0.00103217 0.000400661" />
+                  <joint name="left_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.618 2.618" actuatorfrcrange="-25 25" class="arm_motor" />
+                  <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_shoulder_yaw_link" />
+                  <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_shoulder_yaw_link" />
+                  <body name="left_elbow_link" pos="0.015783 0 -0.080518">
+                    <inertial pos="0.064956 0.004454 -0.010062" quat="0.541765 0.636132 0.388821 0.388129" mass="0.6" diaginertia="0.000443035 0.000421612 0.000259353" />
+                    <joint name="left_elbow_joint" pos="0 0 0" axis="0 1 0" range="-1.0472 2.0944" actuatorfrcrange="-25 25" class="arm_motor" />
+                    <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_elbow_link" />
+                    <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_elbow_link" />
+                    <body name="left_wrist_roll_link" pos="0.1 0.00188791 -0.01">
+                      <inertial pos="0.0171394 0.000537591 4.8864e-07" quat="0.575338 0.411667 -0.574906 0.411094" mass="0.085445" diaginertia="5.48211e-05 4.96646e-05 3.57798e-05" />
+                      <joint name="left_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-1.97222 1.97222" actuatorfrcrange="-25 25" class="arm_motor" />
+                      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_wrist_roll_link" />
+                      <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_roll_link" />
+                      <body name="left_wrist_pitch_link" pos="0.038 0 0">
+                        <inertial pos="0.0229999 -0.00111685 -0.00111658" quat="0.249998 0.661363 0.293036 0.643608" mass="0.48405" diaginertia="0.000430353 0.000429873 0.000164648" />
+                        <joint name="left_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                        <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
+                        <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
+                        <body name="left_wrist_yaw_link" pos="0.046 0 0">
+                          <inertial pos="0.0885506 0.00212216 -0.000374562" quat="0.487149 0.493844 0.513241 0.505358" mass="0.457415" diaginertia="0.00105989 0.000895419 0.000323842" />
+                          <joint name="left_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                          <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="left_wrist_yaw_link" />
+                          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_yaw_link" />
+                          <geom pos="0.0415 0.003 0" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_palm_link" />
+                          <geom pos="0.0415 0.003 0" quat="1 0 0 0" type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_palm_link" contype="0" conaffinity="0" group="4" density="0" />
+                          <body name="left_hand_thumb_0_link" pos="0.067 0.003 0">
+                            <inertial pos="-0.000884246 -0.00863407 0.000944293" quat="0.462991 0.643965 -0.460173 0.398986" mass="0.0862366" diaginertia="1.6546e-05 1.60058e-05 1.43741e-05" />
+                            <joint name="left_hand_thumb_0_joint" pos="0 0 0" axis="0 1 0" range="-1.0472 1.0472" actuatorfrcrange="-2.45 2.45" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_thumb_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_thumb_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="left_hand_thumb_1_link" pos="-0.0025 -0.0193 0">
+                              <inertial pos="-0.000827888 -0.0354744 -0.0003809" quat="0.685598 0.705471 -0.15207 0.0956069" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                              <joint name="left_hand_thumb_1_joint" pos="0 0 0" axis="0 0 1" range="-0.724312 1.0472" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_thumb_1_link" />
+                              <geom size="0.01 0.015 0.01" pos="-0.001 -0.032 0" type="box" rgba="0.7 0.7 0.7 0" contype="0" conaffinity="0" group="4" density="0" />
+                              <body name="left_hand_thumb_2_link" pos="0 -0.0458 0">
+                                <inertial pos="-0.00171735 -0.0262819 0.000107789" quat="0.703174 0.710977 -0.00017564 -0.00766553" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                                <joint name="left_hand_thumb_2_joint" pos="0 0 0" axis="0 0 1" range="0 1.74533" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                                <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_thumb_2_link" />
+                                <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_thumb_2_link" contype="0" conaffinity="0" group="4" density="0" />
+                              </body>
+                            </body>
+                          </body>
+                          <body name="left_hand_middle_0_link" pos="0.1192 0.0046 -0.0285">
+                            <inertial pos="0.0354744 0.000827888 0.0003809" quat="0.391313 0.552395 0.417187 0.606373" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                            <joint name="left_hand_middle_0_joint" pos="0 0 0" axis="0 0 1" range="-1.5708 0" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_middle_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_middle_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="left_hand_middle_1_link" pos="0.0458 0 0">
+                              <inertial pos="0.0262819 0.00171735 -0.000107789" quat="0.502612 0.491799 0.502639 0.502861" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                              <joint name="left_hand_middle_1_joint" pos="0 0 0" axis="0 0 1" range="-1.74533 0" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_middle_1_link" />
+                              <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_middle_1_link" contype="0" conaffinity="0" group="4" density="0" />
+                            </body>
+                          </body>
+                          <body name="left_hand_index_0_link" pos="0.1192 0.0046 0.0285">
+                            <inertial pos="0.0354744 0.000827888 0.0003809" quat="0.391313 0.552395 0.417187 0.606373" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                            <joint name="left_hand_index_0_joint" pos="0 0 0" axis="0 0 1" range="-1.5708 0" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_index_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_index_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="left_hand_index_1_link" pos="0.0458 0 0">
+                              <inertial pos="0.0262819 0.00171735 -0.000107789" quat="0.502612 0.491799 0.502639 0.502861" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                              <joint name="left_hand_index_1_joint" pos="0 0 0" axis="0 0 1" range="-1.74533 0" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="left_hand_index_1_link" />
+                              <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="left_hand_index_1_link" contype="0" conaffinity="0" group="4" density="0" />
+                            </body>
+                          </body>
+                          <body name="left_inspire_L_hand_base_link" pos="0.0365 0 0" quat="0.707106781187 0 0 0.707106781187">
+                            <inertial pos="-0.002551 -0.066047 -0.0019357" mass="0.14143" fullinertia="0.0001234 8.3835e-05 7.7231e-05 2.1995e-06 -1.7694e-06 1.5968e-06" />
+                            <geom type="mesh" mesh="inspire_L_hand_base_link" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                            <body name="left_inspire_L_thumb_proximal_base" pos="-0.01696 -0.0691 0.02045" quat="0.499998163397 0.499999999997 -0.499999999997 0.500001836603">
+                              <inertial pos="0.0048817 0.00038782 -0.00722" mass="0.0018869" fullinertia="5.5158e-08 8.2164e-08 6.7434e-08 -1.1803e-08 -4.6743e-09 -1.3521e-09" />
+                              <joint name="left_inspire_L_thumb_proximal_yaw_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="-0.1 1.3" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link11_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="left_inspire_L_thumb_proximal" pos="0.0099867 0.0098242 -0.0089" quat="0.704570878431 -0.704573466469 -0.0598169453492 0.0598167256297">
+                                <inertial pos="0.021936 -0.01279 -0.0080386" mass="0.0066101" fullinertia="1.5693e-06 1.7356e-06 2.787e-06 7.8339e-07 8.5959e-10 1.0378e-09" />
+                                <joint name="left_inspire_L_thumb_proximal_pitch_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 0.5" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link12_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="left_inspire_L_thumb_intermediate" pos="0.04407 -0.034553 -0.0008">
+                                  <inertial pos="0.0095531 0.0016282 -0.0072002" mass="0.0037844" fullinertia="3.6981e-07 3.2395e-07 4.6532e-07 9.8603e-08 -2.8173e-12 -2.8028e-12" />
+                                  <joint name="left_inspire_L_thumb_intermediate_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 0.8" limited="true" />
+                                  <geom type="mesh" mesh="inspire_Link13_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                  <body name="left_inspire_L_thumb_distal" pos="0.020248 -0.010156 -0.0012">
+                                    <inertial pos="0.0092888 -0.004953 -0.0060033" mass="0.003344" fullinertia="1.3632e-07 1.4052e-07 2.0026e-07 5.6787e-08 -9.1939e-11 1.2145e-10" />
+                                    <joint name="left_inspire_L_thumb_distal_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.2" limited="true" />
+                                    <geom type="mesh" mesh="inspire_Link14_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                    <body name="left_inspire_L_thumb_tip" pos="0.015 -0.013 -0.004" />
+                                  </body>
+                                </body>
+                              </body>
+                            </body>
+                            <body name="left_inspire_L_index_proximal" pos="0.00028533 -0.13653 0.032268" quat="0.999847691535 -0.0174526138857 0 0">
+                              <inertial pos="0.0012971 -0.011934 -0.0059998" mass="0.0042405" fullinertia="6.6215e-07 2.1167e-07 6.9402e-07 1.8442e-08 1.3746e-12 -1.4773e-11" />
+                              <joint name="left_inspire_L_index_proximal_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link15_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="left_inspire_L_index_intermediate" pos="-0.0024229 -0.032041 -0.001">
+                                <inertial pos="0.0021753 -0.019567 -0.005" mass="0.0045682" fullinertia="7.6284e-07 9.4308e-08 7.8176e-07 -8.063e-08 0 0" />
+                                <joint name="left_inspire_L_index_intermediate_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link16_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="left_inspire_L_index_tip" pos="-0.005 -0.04 -0.004" />
+                              </body>
+                            </body>
+                            <body name="left_inspire_L_middle_proximal" pos="0.00028533 -0.1371 0.01295">
+                              <inertial pos="0.0012971 -0.011934 -0.0059999" mass="0.0042405" fullinertia="6.6215e-07 2.1167e-07 6.9402e-07 1.8442e-08 1.2299e-12 -1.4484e-11" />
+                              <joint name="left_inspire_L_middle_proximal_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link17_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="left_inspire_L_middle_intermediate" pos="-0.0024229 -0.032041 -0.001">
+                                <inertial pos="0.001921 -0.020796 -0.0049999" mass="0.0050397" fullinertia="9.5823e-07 1.0646e-07 9.8385e-07 -1.1425e-07 -2.4186e-12 3.6974e-12" />
+                                <joint name="left_inspire_L_middle_intermediate_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link18_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="left_inspire_L_middle_tip" pos="-0.005 -0.045 -0.004" />
+                              </body>
+                            </body>
+                            <body name="left_inspire_L_ring_proximal" pos="0.00028533 -0.13691 -0.0062872" quat="0.999657323373 0.026177009507 0 0">
+                              <inertial pos="0.0012971 -0.011934 -0.0059999" mass="0.0042405" fullinertia="6.6215e-07 2.1167e-07 6.9402e-07 1.8442e-08 0 -1.4124e-11" />
+                              <joint name="left_inspire_L_ring_proximal_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link19_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="left_inspire_L_ring_intermediate" pos="-0.0024229 -0.032041 -0.001">
+                                <inertial pos="0.0021753 -0.019567 -0.005" mass="0.0045682" fullinertia="7.6285e-07 9.4308e-08 7.8176e-07 -8.0631e-08 0 0" />
+                                <joint name="left_inspire_L_ring_intermediate_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link20_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="left_inspire_L_ring_tip" pos="-0.002 -0.04 -0.004" />
+                              </body>
+                            </body>
+                            <body name="left_inspire_L_pinky_proximal" pos="0.00028533 -0.13571 -0.025488" quat="0.998629528347 0.0523360785153 0 0">
+                              <inertial pos="0.0012971 -0.011934 -0.0059999" mass="0.0042405" fullinertia="6.6215e-07 2.1167e-07 6.9402e-07 1.8442e-08 1.0279e-12 -1.4277e-11" />
+                              <joint name="left_inspire_L_pinky_proximal_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link21_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="left_inspire_L_pinky_intermediate" pos="-0.0024229 -0.032041 -0.001">
+                                <inertial pos="0.0024788 -0.016208 -0.0050001" mass="0.0036036" fullinertia="4.3923e-07 7.0315e-08 4.4881e-07 -4.1355e-08 1.2263e-12 3.1311e-12" />
+                                <joint name="left_inspire_L_pinky_intermediate_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link22_L" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="left_inspire_L_pinky_tip" pos="-0.002 -0.032 -0.004" />
+                              </body>
+                            </body>
+                          </body>
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+            <body name="right_shoulder_pitch_link" pos="0.0039563 -0.10021 0.23778" quat="0.990264 -0.139201 1.38722e-05 9.86868e-05">
+              <inertial pos="0 -0.035892 -0.011628" quat="0.68225 -0.326267 0.0130458 0.654152" mass="0.718" diaginertia="0.000465864 0.000432842 0.000406394" />
+              <joint name="right_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.0892 2.6704" actuatorfrcrange="-25 25" class="arm_motor" />
+              <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_shoulder_pitch_link" />
+              <geom size="0.03 0.025" pos="0 -0.04 -0.01" quat="0.707107 0 0.707107 0" type="cylinder" rgba="0.7 0.7 0.7 1" />
+              <body name="right_shoulder_roll_link" pos="0 -0.038 -0.013831" quat="0.990268 0.139172 0 0">
+                <inertial pos="-0.000227 -0.00727 -0.063243" quat="0.712604 -0.00710317 -0.0196223 0.701256" mass="0.643" diaginertia="0.000691311 0.000618011 0.000388977" />
+                <joint name="right_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.2515 1.5882" actuatorfrcrange="-25 25" class="arm_motor" />
+                <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_shoulder_roll_link" />
+                <geom size="0.03 0.015" pos="-0.004 -0.006 -0.053" type="cylinder" rgba="0.7 0.7 0.7 1" />
+                <body name="right_shoulder_yaw_link" pos="0 -0.00624 -0.1032">
+                  <inertial pos="0.010773 0.002949 -0.072009" quat="0.687134 -0.0679942 -0.0964829 0.716879" mass="0.734" diaginertia="0.00106187 0.00103217 0.000400661" />
+                  <joint name="right_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.618 2.618" actuatorfrcrange="-25 25" class="arm_motor" />
+                  <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_shoulder_yaw_link" />
+                  <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_shoulder_yaw_link" />
+                  <body name="right_elbow_link" pos="0.015783 0 -0.080518">
+                    <inertial pos="0.064956 -0.004454 -0.010062" quat="0.388129 0.388821 0.636132 0.541765" mass="0.6" diaginertia="0.000443035 0.000421612 0.000259353" />
+                    <joint name="right_elbow_joint" pos="0 0 0" axis="0 1 0" range="-1.0472 2.0944" actuatorfrcrange="-25 25" class="arm_motor" />
+                    <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_elbow_link" />
+                    <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_elbow_link" />
+                    <body name="right_wrist_roll_link" pos="0.1 -0.00188791 -0.01">
+                      <inertial pos="0.0171394 -0.000537591 4.8864e-07" quat="0.411667 0.575338 -0.411094 0.574906" mass="0.085445" diaginertia="5.48211e-05 4.96646e-05 3.57798e-05" />
+                      <joint name="right_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-1.97222 1.97222" actuatorfrcrange="-25 25" class="arm_motor" />
+                      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_wrist_roll_link" />
+                      <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_roll_link" />
+                      <body name="right_wrist_pitch_link" pos="0.038 0 0">
+                        <inertial pos="0.0229999 0.00111685 -0.00111658" quat="0.643608 0.293036 0.661363 0.249998" mass="0.48405" diaginertia="0.000430353 0.000429873 0.000164648" />
+                        <joint name="right_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                        <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
+                        <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
+                        <body name="right_wrist_yaw_link" pos="0.046 0 0">
+                          <inertial pos="0.0885506 -0.00212216 0.000573742" quat="0.507224 0.511377 0.494292 0.486717" mass="0.457415" diaginertia="0.0010598 0.000895373 0.0003238" />
+                          <joint name="right_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                          <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1" mesh="right_wrist_yaw_link" />
+                          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_yaw_link" />
+                          <geom pos="0.0415 -0.003 0" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_palm_link" />
+                          <geom pos="0.0415 -0.003 0" quat="1 0 0 0" type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_palm_link" contype="0" conaffinity="0" group="4" density="0" />
+                          <body name="right_hand_thumb_0_link" pos="0.067 -0.003 0">
+                            <inertial pos="-0.000884246 0.00863407 0.000944293" quat="0.643965 0.462991 -0.398986 0.460173" mass="0.0862366" diaginertia="1.6546e-05 1.60058e-05 1.43741e-05" />
+                            <joint name="right_hand_thumb_0_joint" pos="0 0 0" axis="0 1 0" range="-1.0472 1.0472" actuatorfrcrange="-2.45 2.45" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_thumb_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_thumb_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="right_hand_thumb_1_link" pos="-0.0025 0.0193 0">
+                              <inertial pos="-0.000827888 0.0354744 -0.0003809" quat="0.705471 0.685598 -0.0956069 0.15207" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                              <joint name="right_hand_thumb_1_joint" pos="0 0 0" axis="0 0 1" range="-1.0472 0.724312" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_thumb_1_link" />
+                              <geom size="0.01 0.015 0.01" pos="-0.001 0.032 0" type="box" rgba="0.7 0.7 0.7 0" contype="0" conaffinity="0" group="4" density="0" />
+                              <body name="right_hand_thumb_2_link" pos="0 0.0458 0">
+                                <inertial pos="-0.00171735 0.0262819 0.000107789" quat="0.710977 0.703174 0.00766553 0.00017564" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                                <joint name="right_hand_thumb_2_joint" pos="0 0 0" axis="0 0 1" range="-1.74533 0" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                                <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_thumb_2_link" />
+                                <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_thumb_2_link" contype="0" conaffinity="0" group="4" density="0" />
+                              </body>
+                            </body>
+                          </body>
+                          <body name="right_hand_middle_0_link" pos="0.1192 -0.0046 -0.0285">
+                            <inertial pos="0.0354744 -0.000827888 0.0003809" quat="0.606373 0.417187 0.552395 0.391313" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                            <joint name="right_hand_middle_0_joint" pos="0 0 0" axis="0 0 1" range="0 1.5708" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_middle_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_middle_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="right_hand_middle_1_link" pos="0.0458 0 0">
+                              <inertial pos="0.0262819 -0.00171735 -0.000107789" quat="0.502861 0.502639 0.491799 0.502612" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                              <joint name="right_hand_middle_1_joint" pos="0 0 0" axis="0 0 1" range="0 1.74533" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_middle_1_link" />
+                              <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_middle_1_link" contype="0" conaffinity="0" group="4" density="0" />
+                            </body>
+                          </body>
+                          <body name="right_hand_index_0_link" pos="0.1192 -0.0046 0.0285">
+                            <inertial pos="0.0354744 -0.000827888 0.0003809" quat="0.606373 0.417187 0.552395 0.391313" mass="0.0588507" diaginertia="1.28514e-05 1.22902e-05 5.9666e-06" />
+                            <joint name="right_hand_index_0_joint" pos="0 0 0" axis="0 0 1" range="0 1.5708" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                            <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_index_0_link" />
+                            <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_index_0_link" contype="0" conaffinity="0" group="4" density="0" />
+                            <body name="right_hand_index_1_link" pos="0.0458 0 0">
+                              <inertial pos="0.0262819 -0.00171735 -0.000107789" quat="0.502861 0.502639 0.491799 0.502612" mass="0.0203063" diaginertia="4.61314e-06 3.86645e-06 1.53495e-06" />
+                              <joint name="right_hand_index_1_joint" pos="0 0 0" axis="0 0 1" range="0 1.74533" actuatorfrcrange="-1.4 1.4" class="finger_motor" />
+                              <geom type="mesh" contype="0" conaffinity="0" group="4" density="0" rgba="0.7 0.7 0.7 0" mesh="right_hand_index_1_link" />
+                              <geom type="mesh" rgba="0.7 0.7 0.7 0" mesh="right_hand_index_1_link" contype="0" conaffinity="0" group="4" density="0" />
+                            </body>
+                          </body>
+                          <body name="right_inspire_R_hand_base_link" pos="0.0365 0 0" quat="0 0.707106781187 -0.707106781187 0">
+                            <inertial pos="-0.0025264 -0.066047 0.0019598" mass="0.14143" fullinertia="0.00012281 8.3832e-05 7.6663e-05 2.1711e-06 1.7709e-06 -1.6551e-06" />
+                            <geom type="mesh" mesh="inspire_R_hand_base_link" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                            <body name="right_inspire_R_thumb_proximal_base" pos="-0.01696 -0.0691 -0.02045" quat="0.499998163397 0.499999999997 -0.499999999997 0.500001836603">
+                              <inertial pos="-0.0048064 0.0009382 -0.00757" mass="0.0018869" fullinertia="5.816e-08 7.9161e-08 6.7433e-08 1.4539e-08 4.491e-09 -1.8727e-09" />
+                              <joint name="right_inspire_R_thumb_proximal_yaw_joint" pos="0 0 0" axis="0 0 -1" damping="0.02" armature="0.0001" range="-0.1 1.3" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link11_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="right_inspire_R_thumb_proximal" pos="-0.0088099 0.010892 -0.00925" quat="0.0996842973055 0.099684663467 0.700046287378 0.700043715969">
+                                <inertial pos="0.021932 0.012785 -0.0080386" mass="0.0066075" fullinertia="1.5686e-06 1.7353e-06 2.786e-06 -7.8296e-07 8.9143e-10 -1.0191e-09" />
+                                <joint name="right_inspire_R_thumb_proximal_pitch_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 0.5" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link12_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="right_inspire_R_thumb_intermediate" pos="0.04407 0.034553 -0.0008">
+                                  <inertial pos="0.0095544 -0.0016282 -0.0071997" mass="0.0037847" fullinertia="3.6981e-07 3.2394e-07 4.6531e-07 -9.8581e-08 -4.7469e-12 1.0939e-12" />
+                                  <joint name="right_inspire_R_thumb_intermediate_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 0.8" limited="true" />
+                                  <geom type="mesh" mesh="inspire_Link13_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                  <body name="right_inspire_R_thumb_distal" pos="0.020248 0.010156 -0.0012">
+                                    <inertial pos="0.0092888 0.0049529 -0.0060033" mass="0.0033441" fullinertia="1.3632e-07 1.4052e-07 2.0026e-07 -5.6788e-08 -9.2764e-11 -1.2283e-10" />
+                                    <joint name="right_inspire_R_thumb_distal_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.2" limited="true" />
+                                    <geom type="mesh" mesh="inspire_Link14_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                    <body name="right_inspire_R_thumb_tip" pos="0.015 0.013 -0.004" />
+                                  </body>
+                                </body>
+                              </body>
+                            </body>
+                            <body name="right_inspire_R_index_proximal" pos="0.00028533 -0.13653 -0.032268" quat="0.0174454417727 -0.999847816701 0 0">
+                              <inertial pos="0.0012259 0.011942 -0.0060001" mass="0.0042403" fullinertia="6.6232e-07 2.1146e-07 6.9398e-07 -1.5775e-08 1.8515e-12 -5.0828e-12" />
+                              <joint name="right_inspire_R_index_proximal_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link15_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="right_inspire_R_index_intermediate" pos="-0.0026138 0.032026 -0.001">
+                                <inertial pos="0.0019697 0.019589 -0.005" mass="0.0045683" fullinertia="7.6111e-07 9.6076e-08 7.8179e-07 8.7637e-08 0 0" />
+                                <joint name="right_inspire_R_index_intermediate_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link16_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="right_inspire_R_index_tip" pos="-0.005 0.04 -0.004" />
+                              </body>
+                            </body>
+                            <body name="right_inspire_R_middle_proximal" pos="0.00028533 -0.1371 -0.01295" quat="3.67320510335e-06 0.999999999993 0 0">
+                              <inertial pos="0.001297 0.011934 -0.0060001" mass="0.0042403" fullinertia="6.6211e-07 2.1167e-07 6.9397e-07 -1.8461e-08 1.8002e-12 -6.6808e-12" />
+                              <joint name="right_inspire_R_middle_proximal_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link17_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="right_inspire_R_middle_intermediate" pos="-0.0024229 0.032041 -0.001">
+                                <inertial pos="0.001921 0.020796 -0.005" mass="0.0050396" fullinertia="9.5822e-07 1.0646e-07 9.8384e-07 1.1425e-07 -2.4791e-12 5.9173e-12" />
+                                <joint name="right_inspire_R_middle_intermediate_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link18_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="right_inspire_R_middle_tip" pos="-0.005 0.045 -0.004" />
+                              </body>
+                            </body>
+                            <body name="right_inspire_R_ring_proximal" pos="0.00028533 -0.13691 0.0062872" quat="0.0261933307036 0.999656895853 0 0">
+                              <inertial pos="0.001297 0.011934 -0.0060002" mass="0.0042403" fullinertia="6.6211e-07 2.1167e-07 6.9397e-07 -1.8461e-08 1.5793e-12 -6.6868e-12" />
+                              <joint name="right_inspire_R_ring_proximal_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link19_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="right_inspire_R_ring_intermediate" pos="-0.0024229 0.032041 -0.001">
+                                <inertial pos="0.0021753 0.019567 -0.005" mass="0.0045683" fullinertia="7.6286e-07 9.431e-08 7.8177e-07 8.0635e-08 0 0" />
+                                <joint name="right_inspire_R_ring_intermediate_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link20_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="right_inspire_R_ring_tip" pos="-0.002 0.04 -0.004" />
+                              </body>
+                            </body>
+                            <body name="right_inspire_R_pinky_proximal" pos="0.00028533 -0.13571 0.025488" quat="0.0523224240441 0.998630243855 0 0">
+                              <inertial pos="0.001297 0.011934 -0.0060001" mass="0.0042403" fullinertia="6.6211e-07 2.1167e-07 6.9397e-07 -1.8461e-08 1.6907e-12 -6.9334e-12" />
+                              <joint name="right_inspire_R_pinky_proximal_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                              <geom type="mesh" mesh="inspire_Link21_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                              <body name="right_inspire_R_pinky_intermediate" pos="-0.0024229 0.032041 -0.001">
+                                <inertial pos="0.0024748 0.016203 -0.0050031" mass="0.0035996" fullinertia="4.3913e-07 7.0247e-08 4.4867e-07 4.1418e-08 3.7168e-11 5.8613e-11" />
+                                <joint name="right_inspire_R_pinky_intermediate_joint" pos="0 0 0" axis="0 0 1" damping="0.02" armature="0.0001" range="0 1.7" limited="true" />
+                                <geom type="mesh" mesh="inspire_Link22_R" rgba="0.08 0.08 0.08 1" contype="1" conaffinity="1" group="1" density="0" condim="4" friction="1.0 0.005 0.0001" />
+                                <body name="right_inspire_R_pinky_tip" pos="-0.002 0.032 -0.004" />
+                              </body>
+                            </body>
+                          </body>
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="left_hip_pitch" joint="left_hip_pitch_joint" ctrlrange="-88 88" />
+    <motor name="left_hip_roll" joint="left_hip_roll_joint" ctrlrange="-88 88" />
+    <motor name="left_hip_yaw" joint="left_hip_yaw_joint" ctrlrange="-88 88" />
+    <motor name="left_knee" joint="left_knee_joint" ctrlrange="-139 139" />
+    <motor name="left_ankle_pitch" joint="left_ankle_pitch_joint" ctrlrange="-50 50" />
+    <motor name="left_ankle_roll" joint="left_ankle_roll_joint" ctrlrange="-50 50" />
+    <motor name="right_hip_pitch" joint="right_hip_pitch_joint" ctrlrange="-88 88" />
+    <motor name="right_hip_roll" joint="right_hip_roll_joint" ctrlrange="-88 88" />
+    <motor name="right_hip_yaw" joint="right_hip_yaw_joint" ctrlrange="-88 88" />
+    <motor name="right_knee" joint="right_knee_joint" ctrlrange="-139 139" />
+    <motor name="right_ankle_pitch" joint="right_ankle_pitch_joint" ctrlrange="-50 50" />
+    <motor name="right_ankle_roll" joint="right_ankle_roll_joint" ctrlrange="-50 50" />
+    <motor name="waist_yaw" joint="waist_yaw_joint" ctrlrange="-88 88" />
+    <motor name="waist_roll" joint="waist_roll_joint" ctrlrange="-50 50" />
+    <motor name="waist_pitch" joint="waist_pitch_joint" ctrlrange="-50 50" />
+    <motor name="left_shoulder_pitch" joint="left_shoulder_pitch_joint" ctrlrange="-25 25" />
+    <motor name="left_shoulder_roll" joint="left_shoulder_roll_joint" ctrlrange="-25 25" />
+    <motor name="left_shoulder_yaw" joint="left_shoulder_yaw_joint" ctrlrange="-25 25" />
+    <motor name="left_elbow" joint="left_elbow_joint" ctrlrange="-25 25" />
+    <motor name="left_wrist_roll" joint="left_wrist_roll_joint" ctrlrange="-25 25" />
+    <motor name="left_wrist_pitch" joint="left_wrist_pitch_joint" ctrlrange="-5 5" />
+    <motor name="left_wrist_yaw" joint="left_wrist_yaw_joint" ctrlrange="-5 5" />
+    <motor name="left_hand_thumb_0" joint="left_hand_thumb_0_joint" ctrlrange="-2.45 2.45" />
+    <motor name="left_hand_thumb_1" joint="left_hand_thumb_1_joint" ctrlrange="-1.4 1.4" />
+    <motor name="left_hand_thumb_2" joint="left_hand_thumb_2_joint" ctrlrange="-1.4 1.4" />
+    <motor name="left_hand_middle_0" joint="left_hand_middle_0_joint" ctrlrange="-1.4 1.4" />
+    <motor name="left_hand_middle_1" joint="left_hand_middle_1_joint" ctrlrange="-1.4 1.4" />
+    <motor name="left_hand_index_0" joint="left_hand_index_0_joint" ctrlrange="-1.4 1.4" />
+    <motor name="left_hand_index_1" joint="left_hand_index_1_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_shoulder_pitch" joint="right_shoulder_pitch_joint" ctrlrange="-25 25" />
+    <motor name="right_shoulder_roll" joint="right_shoulder_roll_joint" ctrlrange="-25 25" />
+    <motor name="right_shoulder_yaw" joint="right_shoulder_yaw_joint" ctrlrange="-25 25" />
+    <motor name="right_elbow" joint="right_elbow_joint" ctrlrange="-25 25" />
+    <motor name="right_wrist_roll" joint="right_wrist_roll_joint" ctrlrange="-25 25" />
+    <motor name="right_wrist_pitch" joint="right_wrist_pitch_joint" ctrlrange="-5 5" />
+    <motor name="right_wrist_yaw" joint="right_wrist_yaw_joint" ctrlrange="-5 5" />
+    <motor name="right_hand_thumb_0" joint="right_hand_thumb_0_joint" ctrlrange="-2.45 2.45" />
+    <motor name="right_hand_thumb_1" joint="right_hand_thumb_1_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_hand_thumb_2" joint="right_hand_thumb_2_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_hand_middle_0" joint="right_hand_middle_0_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_hand_middle_1" joint="right_hand_middle_1_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_hand_index_0" joint="right_hand_index_0_joint" ctrlrange="-1.4 1.4" />
+    <motor name="right_hand_index_1" joint="right_hand_index_1_joint" ctrlrange="-1.4 1.4" />
+    <position name="left_inspire_L_thumb_proximal_yaw_joint" joint="left_inspire_L_thumb_proximal_yaw_joint" kp="20.0" ctrllimited="true" ctrlrange="-0.1 1.3" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_thumb_proximal_pitch_joint" joint="left_inspire_L_thumb_proximal_pitch_joint" kp="20.0" ctrllimited="true" ctrlrange="0 0.5" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_thumb_intermediate_joint" joint="left_inspire_L_thumb_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 0.8" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_thumb_distal_joint" joint="left_inspire_L_thumb_distal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.2" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_index_proximal_joint" joint="left_inspire_L_index_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_index_intermediate_joint" joint="left_inspire_L_index_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_middle_proximal_joint" joint="left_inspire_L_middle_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_middle_intermediate_joint" joint="left_inspire_L_middle_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_ring_proximal_joint" joint="left_inspire_L_ring_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_ring_intermediate_joint" joint="left_inspire_L_ring_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_pinky_proximal_joint" joint="left_inspire_L_pinky_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="left_inspire_L_pinky_intermediate_joint" joint="left_inspire_L_pinky_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_thumb_proximal_yaw_joint" joint="right_inspire_R_thumb_proximal_yaw_joint" kp="20.0" ctrllimited="true" ctrlrange="-0.1 1.3" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_thumb_proximal_pitch_joint" joint="right_inspire_R_thumb_proximal_pitch_joint" kp="20.0" ctrllimited="true" ctrlrange="0 0.5" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_thumb_intermediate_joint" joint="right_inspire_R_thumb_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 0.8" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_thumb_distal_joint" joint="right_inspire_R_thumb_distal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.2" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_index_proximal_joint" joint="right_inspire_R_index_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_index_intermediate_joint" joint="right_inspire_R_index_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_middle_proximal_joint" joint="right_inspire_R_middle_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_middle_intermediate_joint" joint="right_inspire_R_middle_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_ring_proximal_joint" joint="right_inspire_R_ring_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_ring_intermediate_joint" joint="right_inspire_R_ring_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_pinky_proximal_joint" joint="right_inspire_R_pinky_proximal_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+    <position name="right_inspire_R_pinky_intermediate_joint" joint="right_inspire_R_pinky_intermediate_joint" kp="20.0" ctrllimited="true" ctrlrange="0 1.7" forcelimited="true" forcerange="-3.0 3.0" />
+  </actuator>
+  <sensor>
+    <jointpos name="left_hip_pitch_pos" joint="left_hip_pitch_joint" />
+    <jointpos name="left_hip_roll_pos" joint="left_hip_roll_joint" />
+    <jointpos name="left_hip_yaw_pos" joint="left_hip_yaw_joint" />
+    <jointpos name="left_knee_pos" joint="left_knee_joint" />
+    <jointpos name="left_ankle_pitch_pos" joint="left_ankle_pitch_joint" />
+    <jointpos name="left_ankle_roll_pos" joint="left_ankle_roll_joint" />
+    <jointpos name="right_hip_pitch_pos" joint="right_hip_pitch_joint" />
+    <jointpos name="right_hip_roll_pos" joint="right_hip_roll_joint" />
+    <jointpos name="right_hip_yaw_pos" joint="right_hip_yaw_joint" />
+    <jointpos name="right_knee_pos" joint="right_knee_joint" />
+    <jointpos name="right_ankle_pitch_pos" joint="right_ankle_pitch_joint" />
+    <jointpos name="right_ankle_roll_pos" joint="right_ankle_roll_joint" />
+    <jointpos name="waist_yaw_pos" joint="waist_yaw_joint" />
+    <jointpos name="waist_roll_pos" joint="waist_roll_joint" />
+    <jointpos name="waist_pitch_pos" joint="waist_pitch_joint" />
+    <jointpos name="left_shoulder_pitch_pos" joint="left_shoulder_pitch_joint" />
+    <jointpos name="left_shoulder_roll_pos" joint="left_shoulder_roll_joint" />
+    <jointpos name="left_shoulder_yaw_pos" joint="left_shoulder_yaw_joint" />
+    <jointpos name="left_elbow_pos" joint="left_elbow_joint" />
+    <jointpos name="left_wrist_roll_pos" joint="left_wrist_roll_joint" />
+    <jointpos name="left_wrist_pitch_pos" joint="left_wrist_pitch_joint" />
+    <jointpos name="left_wrist_yaw_pos" joint="left_wrist_yaw_joint" />
+    <jointpos name="right_shoulder_pitch_pos" joint="right_shoulder_pitch_joint" />
+    <jointpos name="right_shoulder_roll_pos" joint="right_shoulder_roll_joint" />
+    <jointpos name="right_shoulder_yaw_pos" joint="right_shoulder_yaw_joint" />
+    <jointpos name="right_elbow_pos" joint="right_elbow_joint" />
+    <jointpos name="right_wrist_roll_pos" joint="right_wrist_roll_joint" />
+    <jointpos name="right_wrist_pitch_pos" joint="right_wrist_pitch_joint" />
+    <jointpos name="right_wrist_yaw_pos" joint="right_wrist_yaw_joint" />
+    <jointpos name="left_hand_thumb_0_pos" joint="left_hand_thumb_0_joint" />
+    <jointpos name="left_hand_thumb_1_pos" joint="left_hand_thumb_1_joint" />
+    <jointpos name="left_hand_thumb_2_pos" joint="left_hand_thumb_2_joint" />
+    <jointpos name="left_hand_middle_0_pos" joint="left_hand_middle_0_joint" />
+    <jointpos name="left_hand_middle_1_pos" joint="left_hand_middle_1_joint" />
+    <jointpos name="left_hand_index_0_pos" joint="left_hand_index_0_joint" />
+    <jointpos name="left_hand_index_1_pos" joint="left_hand_index_1_joint" />
+    <jointpos name="right_hand_thumb_0_pos" joint="right_hand_thumb_0_joint" />
+    <jointpos name="right_hand_thumb_1_pos" joint="right_hand_thumb_1_joint" />
+    <jointpos name="right_hand_thumb_2_pos" joint="right_hand_thumb_2_joint" />
+    <jointpos name="right_hand_middle_0_pos" joint="right_hand_middle_0_joint" />
+    <jointpos name="right_hand_middle_1_pos" joint="right_hand_middle_1_joint" />
+    <jointpos name="right_hand_index_0_pos" joint="right_hand_index_0_joint" />
+    <jointpos name="right_hand_index_1_pos" joint="right_hand_index_1_joint" />
+    <jointvel name="left_hip_pitch_vel" joint="left_hip_pitch_joint" />
+    <jointvel name="left_hip_roll_vel" joint="left_hip_roll_joint" />
+    <jointvel name="left_hip_yaw_vel" joint="left_hip_yaw_joint" />
+    <jointvel name="left_knee_vel" joint="left_knee_joint" />
+    <jointvel name="left_ankle_pitch_vel" joint="left_ankle_pitch_joint" />
+    <jointvel name="left_ankle_roll_vel" joint="left_ankle_roll_joint" />
+    <jointvel name="right_hip_pitch_vel" joint="right_hip_pitch_joint" />
+    <jointvel name="right_hip_roll_vel" joint="right_hip_roll_joint" />
+    <jointvel name="right_hip_yaw_vel" joint="right_hip_yaw_joint" />
+    <jointvel name="right_knee_vel" joint="right_knee_joint" />
+    <jointvel name="right_ankle_pitch_vel" joint="right_ankle_pitch_joint" />
+    <jointvel name="right_ankle_roll_vel" joint="right_ankle_roll_joint" />
+    <jointvel name="waist_yaw_vel" joint="waist_yaw_joint" />
+    <jointvel name="waist_roll_vel" joint="waist_roll_joint" />
+    <jointvel name="waist_pitch_vel" joint="waist_pitch_joint" />
+    <jointvel name="left_shoulder_pitch_vel" joint="left_shoulder_pitch_joint" />
+    <jointvel name="left_shoulder_roll_vel" joint="left_shoulder_roll_joint" />
+    <jointvel name="left_shoulder_yaw_vel" joint="left_shoulder_yaw_joint" />
+    <jointvel name="left_elbow_vel" joint="left_elbow_joint" />
+    <jointvel name="left_wrist_roll_vel" joint="left_wrist_roll_joint" />
+    <jointvel name="left_wrist_pitch_vel" joint="left_wrist_pitch_joint" />
+    <jointvel name="left_wrist_yaw_vel" joint="left_wrist_yaw_joint" />
+    <jointvel name="right_shoulder_pitch_vel" joint="right_shoulder_pitch_joint" />
+    <jointvel name="right_shoulder_roll_vel" joint="right_shoulder_roll_joint" />
+    <jointvel name="right_shoulder_yaw_vel" joint="right_shoulder_yaw_joint" />
+    <jointvel name="right_elbow_vel" joint="right_elbow_joint" />
+    <jointvel name="right_wrist_roll_vel" joint="right_wrist_roll_joint" />
+    <jointvel name="right_wrist_pitch_vel" joint="right_wrist_pitch_joint" />
+    <jointvel name="right_wrist_yaw_vel" joint="right_wrist_yaw_joint" />
+    <jointvel name="left_hand_thumb_0_vel" joint="left_hand_thumb_0_joint" />
+    <jointvel name="left_hand_thumb_1_vel" joint="left_hand_thumb_1_joint" />
+    <jointvel name="left_hand_thumb_2_vel" joint="left_hand_thumb_2_joint" />
+    <jointvel name="left_hand_middle_0_vel" joint="left_hand_middle_0_joint" />
+    <jointvel name="left_hand_middle_1_vel" joint="left_hand_middle_1_joint" />
+    <jointvel name="left_hand_index_0_vel" joint="left_hand_index_0_joint" />
+    <jointvel name="left_hand_index_1_vel" joint="left_hand_index_1_joint" />
+    <jointvel name="right_hand_thumb_0_vel" joint="right_hand_thumb_0_joint" />
+    <jointvel name="right_hand_thumb_1_vel" joint="right_hand_thumb_1_joint" />
+    <jointvel name="right_hand_thumb_2_vel" joint="right_hand_thumb_2_joint" />
+    <jointvel name="right_hand_middle_0_vel" joint="right_hand_middle_0_joint" />
+    <jointvel name="right_hand_middle_1_vel" joint="right_hand_middle_1_joint" />
+    <jointvel name="right_hand_index_0_vel" joint="right_hand_index_0_joint" />
+    <jointvel name="right_hand_index_1_vel" joint="right_hand_index_1_joint" />
+    <jointactuatorfrc name="left_hip_pitch_torque" joint="left_hip_pitch_joint" />
+    <jointactuatorfrc name="left_hip_roll_torque" joint="left_hip_roll_joint" />
+    <jointactuatorfrc name="left_hip_yaw_torque" joint="left_hip_yaw_joint" />
+    <jointactuatorfrc name="left_knee_torque" joint="left_knee_joint" />
+    <jointactuatorfrc name="left_ankle_pitch_torque" joint="left_ankle_pitch_joint" />
+    <jointactuatorfrc name="left_ankle_roll_torque" joint="left_ankle_roll_joint" />
+    <jointactuatorfrc name="right_hip_pitch_torque" joint="right_hip_pitch_joint" />
+    <jointactuatorfrc name="right_hip_roll_torque" joint="right_hip_roll_joint" />
+    <jointactuatorfrc name="right_hip_yaw_torque" joint="right_hip_yaw_joint" />
+    <jointactuatorfrc name="right_knee_torque" joint="right_knee_joint" />
+    <jointactuatorfrc name="right_ankle_pitch_torque" joint="right_ankle_pitch_joint" />
+    <jointactuatorfrc name="right_ankle_roll_torque" joint="right_ankle_roll_joint" />
+    <jointactuatorfrc name="waist_yaw_torque" joint="waist_yaw_joint" />
+    <jointactuatorfrc name="waist_roll_torque" joint="waist_roll_joint" />
+    <jointactuatorfrc name="waist_pitch_torque" joint="waist_pitch_joint" />
+    <jointactuatorfrc name="left_shoulder_pitch_torque" joint="left_shoulder_pitch_joint" />
+    <jointactuatorfrc name="left_shoulder_roll_torque" joint="left_shoulder_roll_joint" />
+    <jointactuatorfrc name="left_shoulder_yaw_torque" joint="left_shoulder_yaw_joint" />
+    <jointactuatorfrc name="left_elbow_torque" joint="left_elbow_joint" />
+    <jointactuatorfrc name="left_wrist_roll_torque" joint="left_wrist_roll_joint" />
+    <jointactuatorfrc name="left_wrist_pitch_torque" joint="left_wrist_pitch_joint" />
+    <jointactuatorfrc name="left_wrist_yaw_torque" joint="left_wrist_yaw_joint" />
+    <jointactuatorfrc name="right_shoulder_pitch_torque" joint="right_shoulder_pitch_joint" />
+    <jointactuatorfrc name="right_shoulder_roll_torque" joint="right_shoulder_roll_joint" />
+    <jointactuatorfrc name="right_shoulder_yaw_torque" joint="right_shoulder_yaw_joint" />
+    <jointactuatorfrc name="right_elbow_torque" joint="right_elbow_joint" />
+    <jointactuatorfrc name="right_wrist_roll_torque" joint="right_wrist_roll_joint" />
+    <jointactuatorfrc name="right_wrist_pitch_torque" joint="right_wrist_pitch_joint" />
+    <jointactuatorfrc name="right_wrist_yaw_torque" joint="right_wrist_yaw_joint" />
+    <jointactuatorfrc name="left_hand_thumb_0_torque" joint="left_hand_thumb_0_joint" />
+    <jointactuatorfrc name="left_hand_thumb_1_torque" joint="left_hand_thumb_1_joint" />
+    <jointactuatorfrc name="left_hand_thumb_2_torque" joint="left_hand_thumb_2_joint" />
+    <jointactuatorfrc name="left_hand_middle_0_torque" joint="left_hand_middle_0_joint" />
+    <jointactuatorfrc name="left_hand_middle_1_torque" joint="left_hand_middle_1_joint" />
+    <jointactuatorfrc name="left_hand_index_0_torque" joint="left_hand_index_0_joint" />
+    <jointactuatorfrc name="left_hand_index_1_torque" joint="left_hand_index_1_joint" />
+    <jointactuatorfrc name="right_hand_thumb_0_torque" joint="right_hand_thumb_0_joint" />
+    <jointactuatorfrc name="right_hand_thumb_1_torque" joint="right_hand_thumb_1_joint" />
+    <jointactuatorfrc name="right_hand_thumb_2_torque" joint="right_hand_thumb_2_joint" />
+    <jointactuatorfrc name="right_hand_middle_0_torque" joint="right_hand_middle_0_joint" />
+    <jointactuatorfrc name="right_hand_middle_1_torque" joint="right_hand_middle_1_joint" />
+    <jointactuatorfrc name="right_hand_index_0_torque" joint="right_hand_index_0_joint" />
+    <jointactuatorfrc name="right_hand_index_1_torque" joint="right_hand_index_1_joint" />
+    <framequat name="imu_quat" objtype="site" objname="imu" />
+    <gyro name="imu_gyro" site="imu" />
+    <accelerometer name="imu_acc" site="imu" />
+    <framepos name="frame_pos" objtype="site" objname="imu" />
+    <framelinvel name="frame_vel" objtype="site" objname="imu" />
+  </sensor>
+</mujoco>

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/L_hand_base_link.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/L_hand_base_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33ab4e97801bd5421903a78f5977a44e477ae8653eaf32358d35633e465411e0
+size 1448084

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link11_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link11_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d87cb704d80de840555d0a393117d32f9bd5e91425e0458363e0a799aa4e5339
+size 46584

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link11_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link11_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b49b6463f801f0402bac9c65bb989c4097f6d2c1fa1597ba560aedd640561778
+size 46884

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link12_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link12_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f35b78a9cab1007ac8b73023a5862ed055d33951b5742f9a783997d38e99551
+size 917284

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link12_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link12_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:347212bdb22d80fb364dd889de934d6fbb935e38d1f24c682caed84f7b6ea8cb
+size 921984

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link13_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link13_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e93b55f2ae73fe0f62cd27e81d8a4620211068cb1c9b25e6414e802a37541ee
+size 488584

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link13_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link13_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c157dfe5b666efb1c3d51342e56f5caad2fc350930ac21ee1e02d956c1034ca3
+size 483284

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link14_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link14_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b677bcdcddcd90ff4b005f83daa9e50eb4003d5e67ea4eeefbf857718716c164
+size 155184

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link14_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link14_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:564aa8c3d2ff0e51b75736a8b01b4c309c7098582a424ea1391ccb75125519d8
+size 155584

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link15_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link15_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c601e7aa8e1c91310a75190dfb6b95a8dc981b707e5f104f9ca9ecbea118b34
+size 407184

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link15_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link15_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09c120f7fb7761aa97d89240cd8cb8e30c40ee60093cbb8b1c2e13a68a8e3845
+size 411884

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link16_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link16_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d8508c65db44e2349f37e8ab4c057d204a40093d4733897ae5b51075b00f5e9
+size 329384

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link16_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link16_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6942ada1189cdf442124c6b8935f3e3a3ae310092a3a1414fdeb0bd6d23578bb
+size 335484

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link17_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link17_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca2a68fed635eca290b234fbdc649779036ba5bac753addcb7ce6a086ad95949
+size 407184

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link17_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link17_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36fc62c609800ce6d4521ae6f3c4c9b8a732be28654f32f04893696c17e6930c
+size 411884

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link18_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link18_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9425aea7ebbf6d1dfb2eb0714fb44dfaea6b6a81c71d6e96c8d3950f636dfa62
+size 182684

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link18_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link18_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9711fac7df0c09a372e1529f74b9d506d37abf3ebc3241d976ad45e5ee7e2d69
+size 182984

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link19_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link19_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbb256a70c17e21c995df66807f0755dc136d0312df245112d6d4bfcd29c43a4
+size 407184

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link19_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link19_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46619bd6a887615d7dfe850d39a6f5d8f8c5ecfa9429c567338f3a659a5d4d75
+size 411884

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link20_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link20_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9145af7a515bce4c1c06d16b5be8900ec3f8375fc8e34d371315ce76f600877
+size 329484

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link20_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link20_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a517debff6b924c22ae0f87dbb6aac199a1f130c7fef353a7d659e365f30b1f4
+size 334784

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link21_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link21_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:180ab4ac01dab60407d0b33819883eb0ec869e4d4f349f786972135c7114fc0d
+size 407184

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link21_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link21_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed0a29d2376e8874f724bc2c20384eeec93d8268e59bb8c45628335f7ab6742e
+size 411884

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link22_L.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link22_L.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e64ea976ecf08c46e8cb80a5dd56ee3e8c5f36a0573ab3c69160d9337f941e1
+size 413384

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link22_R.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/Link22_R.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa3fb46f689251ee38f5262b71364c680f70d1ad1dd9c6f1cae8c098b0e8422
+size 416484

--- a/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/R_hand_base_link.STL
+++ b/gear_sonic/data/robot_model/model_data/g1/meshes/inspire_hand/R_hand_base_link.STL
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d84504242a99fa915c4ed5195ce4724c67cb94d9217cd4c254cfb5937ecf5c
+size 1472384

--- a/gear_sonic/data/robot_model/model_data/g1/scene_43dof_inspire_hand.xml
+++ b/gear_sonic/data/robot_model/model_data/g1/scene_43dof_inspire_hand.xml
@@ -1,0 +1,29 @@
+<mujoco model="g1_43dof_inspire_hand scene">
+  <include file="g1_29dof_with_inspire_hand.xml"/>
+  <!-- Inspire hand joints/actuators are added for simulation; Dex3 hand joints remain hidden for DDS compatibility. -->
+
+  <statistic center="0 0 0.5" extent="2.0"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="-130" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    <site name="com_marker" pos="0.1 0 0" size="0.05" rgba="1 0 0 1" type="sphere"/>
+  </worldbody>
+
+  <default>
+    <geom friction="1.0"/>
+  </default>
+</mujoco>

--- a/gear_sonic/utils/mujoco_sim/base_sim.py
+++ b/gear_sonic/utils/mujoco_sim/base_sim.py
@@ -5,6 +5,7 @@ commands, steps physics, and publishes observations back via the SDK bridge.
 BaseSimulator wraps DefaultEnv with rate-limiting and viewer/image update loops.
 """
 
+import json
 import os
 import pathlib
 from pathlib import Path
@@ -27,6 +28,33 @@ from gear_sonic.utils.mujoco_sim.unitree_sdk2py_bridge import ElasticBand, Unitr
 from gear_sonic.utils.mujoco_sim.robot import Robot
 
 GEAR_SONIC_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+ZMQ_PACKED_HEADER_SIZE = 1280
+INSPIRE_HAND_COMMAND_OPEN = np.array([1000, 1000, 1000, 1000, 800, 200], dtype=np.float64)
+INSPIRE_HAND_COMMAND_CLOSE = np.array([0, 0, 0, 0, 200, 800], dtype=np.float64)
+INSPIRE_HAND_SIDE_PREFIX = {
+    "left": "left_inspire_L_",
+    "right": "right_inspire_R_",
+}
+INSPIRE_HAND_FINGER_SUFFIXES = {
+    "little": ("pinky_proximal_joint", "pinky_intermediate_joint"),
+    "ring": ("ring_proximal_joint", "ring_intermediate_joint"),
+    "middle": ("middle_proximal_joint", "middle_intermediate_joint"),
+    "index": ("index_proximal_joint", "index_intermediate_joint"),
+}
+INSPIRE_HAND_COMMAND_INDEX = {
+    "little": 0,
+    "ring": 1,
+    "middle": 2,
+    "index": 3,
+    "thumb_bend": 4,
+    "thumb_rot": 5,
+}
+INSPIRE_HAND_THUMB_BEND_SUFFIXES = (
+    "thumb_proximal_pitch_joint",
+    "thumb_intermediate_joint",
+    "thumb_distal_joint",
+)
+INSPIRE_HAND_THUMB_ROT_SUFFIX = "thumb_proximal_yaw_joint"
 
 
 class DefaultEnv:
@@ -48,9 +76,12 @@ class DefaultEnv:
         self.num_hand_dof = self.robot.NUM_HAND_JOINTS
         self.sim_dt = self.config["SIMULATE_DT"]
         self.obs = None
-        self.torques = np.zeros(self.num_body_dof + self.num_hand_dof * 2)
-        self.torque_limit = np.array(self.robot.MOTOR_EFFORT_LIMIT_LIST)
+        self.torques = None
+        self.torque_limit = np.array(self.robot.MOTOR_EFFORT_LIMIT_LIST, dtype=np.float64)
         self.camera_configs = camera_configs
+        self.inspire_hand_socket = None
+        self.inspire_hand_targets = {"left": {}, "right": {}}
+        self.inspire_hand_actuator_index = {}
 
         if not camera_configs and offscreen and enable_image_publish:
             self.camera_configs = {
@@ -225,6 +256,9 @@ class DefaultEnv:
         self.body_joint_index = []
         self.left_hand_index = []
         self.right_hand_index = []
+        self.body_joint_names = []
+        self.left_hand_joint_names = []
+        self.right_hand_joint_names = []
         for i in range(self.mj_model.njnt):
             name = self.mj_model.joint(i).name
             if any(
@@ -234,10 +268,13 @@ class DefaultEnv:
                 ]
             ):
                 self.body_joint_index.append(i)
+                self.body_joint_names.append(name)
             elif "left_hand" in name:
                 self.left_hand_index.append(i)
+                self.left_hand_joint_names.append(name)
             elif "right_hand" in name:
                 self.right_hand_index.append(i)
+                self.right_hand_joint_names.append(name)
 
         assert len(self.body_joint_index) == self.robot.NUM_JOINTS
         assert len(self.left_hand_index) == self.robot.NUM_HAND_JOINTS
@@ -246,6 +283,180 @@ class DefaultEnv:
         self.body_joint_index = np.array(self.body_joint_index)
         self.left_hand_index = np.array(self.left_hand_index)
         self.right_hand_index = np.array(self.right_hand_index)
+        self._init_actuator_indices()
+        self._init_inspire_hand_control()
+
+    def _actuator_ids_for_joint_indices(self, joint_indices: np.ndarray, label: str) -> np.ndarray:
+        actuator_ids = []
+        for joint_id in joint_indices:
+            matches = np.where(self.mj_model.actuator_trnid[:, 0] == int(joint_id))[0]
+            if len(matches) == 0:
+                joint_name = self.mj_model.joint(int(joint_id)).name
+                raise ValueError(f"No actuator found for {label} joint '{joint_name}'")
+            actuator_ids.append(int(matches[0]))
+        return np.array(actuator_ids, dtype=np.int64)
+
+    def _init_actuator_indices(self):
+        self.body_actuator_index = self._actuator_ids_for_joint_indices(
+            self.body_joint_index, "body"
+        )
+        self.left_hand_actuator_index = self._actuator_ids_for_joint_indices(
+            self.left_hand_index, "left hand"
+        )
+        self.right_hand_actuator_index = self._actuator_ids_for_joint_indices(
+            self.right_hand_index, "right hand"
+        )
+
+        self.torques = np.zeros(self.mj_model.nu, dtype=np.float64)
+        self.ctrl_limit = np.full(self.mj_model.nu, np.inf, dtype=np.float64)
+        limit_count = min(len(self.torque_limit), self.mj_model.nu)
+        self.ctrl_limit[:limit_count] = self.torque_limit[:limit_count]
+
+    def _joint_target_from_unit(self, joint_name: str, unit_value: float) -> float:
+        joint_id = mujoco.mj_name2id(self.mj_model, mujoco.mjtObj.mjOBJ_JOINT, joint_name)
+        if joint_id < 0:
+            raise ValueError(f"Inspire hand joint '{joint_name}' is missing from the MuJoCo model")
+        lower, upper = self.mj_model.jnt_range[joint_id]
+        unit = float(np.clip(unit_value, 0.0, 1.0))
+        return float(lower + unit * (upper - lower))
+
+    def _inspire_command_to_joint_targets(self, side: str, command: np.ndarray) -> Dict[str, float]:
+        command = np.asarray(command, dtype=np.float64).reshape(6)
+        open_values = np.asarray(
+            self.config.get("INSPIRE_HAND_COMMAND_OPEN", INSPIRE_HAND_COMMAND_OPEN),
+            dtype=np.float64,
+        )
+        close_values = np.asarray(
+            self.config.get("INSPIRE_HAND_COMMAND_CLOSE", INSPIRE_HAND_COMMAND_CLOSE),
+            dtype=np.float64,
+        )
+        denom = close_values - open_values
+        units = np.zeros(6, dtype=np.float64)
+        valid = np.abs(denom) > 1e-8
+        units[valid] = (command[valid] - open_values[valid]) / denom[valid]
+        units = np.clip(units, 0.0, 1.0)
+
+        prefix = INSPIRE_HAND_SIDE_PREFIX[side]
+        targets = {}
+        for channel, suffixes in INSPIRE_HAND_FINGER_SUFFIXES.items():
+            unit = units[INSPIRE_HAND_COMMAND_INDEX[channel]]
+            for suffix in suffixes:
+                joint_name = prefix + suffix
+                targets[joint_name] = self._joint_target_from_unit(joint_name, unit)
+
+        thumb_bend = units[INSPIRE_HAND_COMMAND_INDEX["thumb_bend"]]
+        for suffix in INSPIRE_HAND_THUMB_BEND_SUFFIXES:
+            joint_name = prefix + suffix
+            targets[joint_name] = self._joint_target_from_unit(joint_name, thumb_bend)
+
+        thumb_rot = units[INSPIRE_HAND_COMMAND_INDEX["thumb_rot"]]
+        joint_name = prefix + INSPIRE_HAND_THUMB_ROT_SUFFIX
+        targets[joint_name] = self._joint_target_from_unit(joint_name, thumb_rot)
+        return targets
+
+    def _init_inspire_hand_control(self):
+        self.inspire_hand_actuator_index = {}
+        for prefix in INSPIRE_HAND_SIDE_PREFIX.values():
+            suffixes = [INSPIRE_HAND_THUMB_ROT_SUFFIX, *INSPIRE_HAND_THUMB_BEND_SUFFIXES]
+            for finger_suffixes in INSPIRE_HAND_FINGER_SUFFIXES.values():
+                suffixes.extend(finger_suffixes)
+            for suffix in suffixes:
+                joint_name = prefix + suffix
+                actuator_id = mujoco.mj_name2id(
+                    self.mj_model, mujoco.mjtObj.mjOBJ_ACTUATOR, joint_name
+                )
+                if actuator_id >= 0:
+                    self.inspire_hand_actuator_index[joint_name] = actuator_id
+
+        if self.inspire_hand_actuator_index:
+            self.inspire_hand_targets = {
+                "left": self._inspire_command_to_joint_targets("left", INSPIRE_HAND_COMMAND_OPEN),
+                "right": self._inspire_command_to_joint_targets("right", INSPIRE_HAND_COMMAND_OPEN),
+            }
+
+        if not self.config.get("ENABLE_INSPIRE_HAND_ZMQ", False):
+            return
+
+        if not self.inspire_hand_actuator_index:
+            print("Warning: ENABLE_INSPIRE_HAND_ZMQ is set, but no Inspire hand actuators exist.")
+            return
+
+        try:
+            import zmq
+        except ImportError:
+            print("Warning: pyzmq is not installed; Inspire hand ZMQ control is disabled.")
+            return
+
+        host = self.config.get("INSPIRE_HAND_ZMQ_HOST", "localhost")
+        port = int(self.config.get("INSPIRE_HAND_ZMQ_PORT", 5556))
+        self.inspire_hand_topic = self.config.get("INSPIRE_HAND_ZMQ_TOPIC", "inspire_hand")
+        self.inspire_hand_header_size = int(
+            self.config.get("INSPIRE_HAND_ZMQ_HEADER_SIZE", ZMQ_PACKED_HEADER_SIZE)
+        )
+        self._inspire_zmq = zmq
+        self.inspire_hand_context = zmq.Context.instance()
+        self.inspire_hand_socket = self.inspire_hand_context.socket(zmq.SUB)
+        self.inspire_hand_socket.setsockopt_string(zmq.SUBSCRIBE, self.inspire_hand_topic)
+        self.inspire_hand_socket.setsockopt(zmq.CONFLATE, 1)
+        self.inspire_hand_socket.connect(f"tcp://{host}:{port}")
+        print(
+            f"[InspireHandSim] Listening on tcp://{host}:{port} topic='{self.inspire_hand_topic}'"
+        )
+
+    def _decode_zmq_fields(self, payload: bytes, fields: list[dict]) -> Dict[str, np.ndarray]:
+        dtypes = {
+            "f32": np.float32,
+            "f64": np.float64,
+            "i32": np.int32,
+            "u8": np.uint8,
+        }
+        decoded = {}
+        offset = 0
+        for field in fields:
+            dtype = dtypes[field["dtype"]]
+            shape = tuple(field.get("shape", [1]))
+            count = int(np.prod(shape))
+            nbytes = np.dtype(dtype).itemsize * count
+            decoded[field["name"]] = (
+                np.frombuffer(payload, dtype=dtype, count=count, offset=offset)
+                .astype(np.float64)
+                .reshape(shape)
+            )
+            offset += nbytes
+        return decoded
+
+    def _poll_inspire_hand_zmq(self):
+        if self.inspire_hand_socket is None:
+            return
+
+        topic = self.inspire_hand_topic.encode("utf-8")
+        for _ in range(8):
+            try:
+                message = self.inspire_hand_socket.recv(flags=self._inspire_zmq.NOBLOCK)
+            except self._inspire_zmq.Again:
+                return
+
+            if not message.startswith(topic):
+                continue
+            header_start = len(topic)
+            header_end = header_start + self.inspire_hand_header_size
+            header_raw = message[header_start:header_end].split(b"\0", 1)[0]
+            if not header_raw:
+                continue
+            header = json.loads(header_raw.decode("utf-8"))
+            values = self._decode_zmq_fields(message[header_end:], header.get("fields", []))
+            for side in ("left", "right"):
+                if side in values:
+                    self.inspire_hand_targets[side] = self._inspire_command_to_joint_targets(
+                        side, values[side]
+                    )
+
+    def _write_inspire_hand_targets(self, ctrl: np.ndarray):
+        for targets in self.inspire_hand_targets.values():
+            for joint_name, target in targets.items():
+                actuator_id = self.inspire_hand_actuator_index.get(joint_name)
+                if actuator_id is not None:
+                    ctrl[actuator_id] = target
 
     def init_renderers(self):
         self.renderers = {}
@@ -373,16 +584,18 @@ class DefaultEnv:
         obs["body_q"] = self.mj_data.qpos[self.body_joint_index + 7 - 1]
         obs["body_dq"] = self.mj_data.qvel[self.body_joint_index + 6 - 1]
         obs["body_ddq"] = self.mj_data.qacc[self.body_joint_index + 6 - 1]
-        obs["body_tau_est"] = self.mj_data.actuator_force[self.body_joint_index - 1]
+        obs["body_tau_est"] = self.mj_data.actuator_force[self.body_actuator_index]
         if self.num_hand_dof > 0:
             obs["left_hand_q"] = self.mj_data.qpos[self.left_hand_index + self.qpos_offset - 1]
             obs["left_hand_dq"] = self.mj_data.qvel[self.left_hand_index + self.qvel_offset - 1]
             obs["left_hand_ddq"] = self.mj_data.qacc[self.left_hand_index + self.qvel_offset - 1]
-            obs["left_hand_tau_est"] = self.mj_data.actuator_force[self.left_hand_index - 1]
+            obs["left_hand_tau_est"] = self.mj_data.actuator_force[self.left_hand_actuator_index]
             obs["right_hand_q"] = self.mj_data.qpos[self.right_hand_index + self.qpos_offset - 1]
             obs["right_hand_dq"] = self.mj_data.qvel[self.right_hand_index + self.qvel_offset - 1]
             obs["right_hand_ddq"] = self.mj_data.qacc[self.right_hand_index + self.qvel_offset - 1]
-            obs["right_hand_tau_est"] = self.mj_data.actuator_force[self.right_hand_index - 1]
+            obs["right_hand_tau_est"] = self.mj_data.actuator_force[
+                self.right_hand_actuator_index
+            ]
         obs["time"] = self.mj_data.time
         return obs
 
@@ -414,19 +627,17 @@ class DefaultEnv:
                 self.mj_data.xfrc_applied[self.band_attached_link] = np.zeros(6)
         body_torques = self.compute_body_torques()
         hand_torques = self.compute_hand_torques()
-        # -1: actuator array is 0-based while joint indices from the model are 1-based
-        self.torques[self.body_joint_index - 1] = body_torques
+        ctrl = np.zeros(self.mj_model.nu, dtype=np.float64)
+        ctrl[self.body_actuator_index] = body_torques
         if self.num_hand_dof > 0:
-            self.torques[self.left_hand_index - 1] = hand_torques[: self.num_hand_dof]
-            self.torques[self.right_hand_index - 1] = hand_torques[self.num_hand_dof :]
+            ctrl[self.left_hand_actuator_index] = hand_torques[: self.num_hand_dof]
+            ctrl[self.right_hand_actuator_index] = hand_torques[self.num_hand_dof :]
 
-        self.torques = np.clip(self.torques, -self.torque_limit, self.torque_limit)
+        self._poll_inspire_hand_zmq()
+        self._write_inspire_hand_targets(ctrl)
+        ctrl = np.clip(ctrl, -self.ctrl_limit, self.ctrl_limit)
 
-        if self.config["FREE_BASE"]:
-            # Prepend 6 zeros for the floating-base root DOF actuators
-            self.mj_data.ctrl = np.concatenate((np.zeros(6), self.torques))
-        else:
-            self.mj_data.ctrl = self.torques
+        self.mj_data.ctrl[:] = ctrl
         mujoco.mj_step(self.mj_model, self.mj_data)
 
         self.check_fall()
@@ -645,6 +856,9 @@ class BaseSimulator:
     def close(self):
         self._running = False
         try:
+            if getattr(self.sim_env, "inspire_hand_socket", None) is not None:
+                self.sim_env.inspire_hand_socket.close(0)
+                self.sim_env.inspire_hand_socket = None
             if self.sim_env.image_publish_process is not None:
                 self.sim_env.image_publish_process.stop()
             if self.sim_env.viewer is not None:

--- a/gear_sonic/utils/mujoco_sim/wbc_configs/g1_29dof_sonic_model12.yaml
+++ b/gear_sonic/utils/mujoco_sim/wbc_configs/g1_29dof_sonic_model12.yaml
@@ -1,6 +1,6 @@
 # copy from g1_43dof_hist.yaml
 ROBOT_TYPE: 'g1_29dof' # Robot name, "go2", "b2", "b2w", "h1", "go2w", "g1" 
-ROBOT_SCENE: "gear_sonic/data/robot_model/model_data/g1/scene_43dof.xml" # Robot scene, for Sim2Sim
+ROBOT_SCENE: "gear_sonic/data/robot_model/model_data/g1/scene_43dof_inspire_hand.xml" # Robot scene, for Sim2Sim
 # ROBOT_SCENE: "gear_sonic/data/robot_model/model_data/g1/scene_29dof_activated3dex.xml"
 
 DOMAIN_ID: 0 # Domain id
@@ -9,6 +9,11 @@ DOMAIN_ID: 0 # Domain id
 # INTERFACE: "enxc8a3623c9cb7"
 INTERFACE: "lo"
 SIMULATOR: "mujoco"  # "robocasa"
+
+ENABLE_INSPIRE_HAND_ZMQ: True
+INSPIRE_HAND_ZMQ_HOST: "localhost"
+INSPIRE_HAND_ZMQ_PORT: 5556
+INSPIRE_HAND_ZMQ_TOPIC: "inspire_hand"
 
 USE_JOYSTICK: 0 # Simulate Unitree WirelessController using a gamepad (0: disable, 1: enable)
 JOYSTICK_TYPE: "xbox" # support "xbox" and "switch" gamepad layout


### PR DESCRIPTION
## Summary
- add a G1 MuJoCo scene/model with Inspire five-finger hands attached
- keep the original Dex3 hand joints hidden for DDS/SONIC compatibility while adding Inspire hand joints and position actuators for simulation
- add MuJoCo control-layer support for the inspire_hand ZMQ topic published by the AVP bridge
- switch the SONIC MuJoCo config to the Inspire-hand scene and enable hand ZMQ input

## Validation
- git diff --cached --check
- python3 -m py_compile gear_sonic/utils/mujoco_sim/base_sim.py
- loaded gear_sonic/data/robot_model/model_data/g1/scene_43dof_inspire_hand.xml with MuJoCo: nq=74, nv=73, nu=67, ngeom=130

## Notes
- The Inspire STL assets are stored through Git LFS.
- This PR intentionally excludes unrelated local deploy changes in gear_sonic_deploy/.