### PR TITLE
Handle zero-norm elbow swing quaternions in PICO streamer

### DIFF
--- a/gear_sonic/scripts/pico_manager_thread_server.py
+++ b/gear_sonic/scripts/pico_manager_thread_server.py
@@ -1162,6 +1162,31 @@ class ThreePointPose:
         print(f"[{self.log_prefix}] Wrist recalibration pending (neck preserved, measured q)")
 
 
+def _normalize_quat_xyzw_or_identity(q, name="quat"):
+    """Normalize xyzw quaternions and replace invalid rows with identity."""
+    q = np.asarray(q, dtype=np.float64)
+
+    if q.ndim == 1:
+        q = q.reshape(1, 4)
+
+    if q.shape[-1] != 4:
+        raise ValueError(f"{name} expected shape (..., 4), got {q.shape}")
+
+    norms = np.linalg.norm(q, axis=1)
+    bad = (~np.isfinite(q).all(axis=1)) | (~np.isfinite(norms)) | (norms < 1e-8)
+
+    if np.any(bad):
+        print(
+            f"[PoseLoop][WARN] invalid {name} rows "
+            f"{np.where(bad)[0].tolist()} -> identity quaternion"
+        )
+        q = q.copy()
+        q[bad] = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+        norms = np.linalg.norm(q, axis=1)
+
+    return (q / norms[:, None]).astype(np.float32)
+
+
 class PoseStreamer:
     """Encapsulates the pose streaming loop state and logic."""
 
@@ -1376,10 +1401,19 @@ class PoseStreamer:
         )
 
         # Move elbow roll/yaw into wrist while preserving wrist pitch from SMPL
-        l_elbow_swing_euler = R.from_quat(g1_l_elbow_q_swing[:, [1, 2, 3, 0]]).as_euler(
+        l_elbow_swing_quat = _normalize_quat_xyzw_or_identity(
+            g1_l_elbow_q_swing[:, [1, 2, 3, 0]],
+            "left_elbow_swing",
+        )
+        r_elbow_swing_quat = _normalize_quat_xyzw_or_identity(
+            g1_r_elbow_q_swing[:, [1, 2, 3, 0]],
+            "right_elbow_swing",
+        )
+
+        l_elbow_swing_euler = R.from_quat(l_elbow_swing_quat).as_euler(
             "XYZ", degrees=False
         )
-        r_elbow_swing_euler = R.from_quat(g1_r_elbow_q_swing[:, [1, 2, 3, 0]]).as_euler(
+        r_elbow_swing_euler = R.from_quat(r_elbow_swing_quat).as_euler(
             "XYZ", degrees=False
         )
 


### PR DESCRIPTION
### Summary

First, thank you for releasing GR00T-WholeBodyControl. After this local fix, onboard PICO teleop on G1 has been working very well in my setup.

This PR adds validation and normalization for elbow swing quaternions in `pico_manager_thread_server.py` before passing them to `scipy.spatial.transform.Rotation.from_quat`.

In some POSE-mode frames, the elbow swing rotation can become a zero-norm or non-finite quaternion. `Rotation.from_quat()` then raises:
```
ValueError: Found zero norm quaternions in `quat`
```
This crashes the PICO manager process. In a real-robot teleop setup, the C++ deployment may continue holding the last streamed target until manually stopped, so preventing the Python streamer crash is safety-relevant.

Fixes #163.
### Fix

This PR adds a local helper in `pico_manager_thread_server.py` that:

- checks whether quaternion values are finite,
- checks for zero-norm quaternions,
- replaces invalid rows with identity quaternion,
- normalizes valid rows before passing them to SciPy.

The fix is intentionally kept local to the PICO pose streamer to avoid changing behavior of shared rotation utilities.

### Environment

- Robot: Unitree G1 EDU
- Deployment: onboard Jetson Orin NX
- OS: Ubuntu 22.04 / JetPack 6.2 / L4T R36.4.3
- Architecture: aarch64
- CUDA: 12.6
- TensorRT: 10.7.0.23 L4T aarch64
- Teleop: PICO 4 Ultra + XRoboToolkit + body trackers (legs only)
- Input mode: `zmq_manager` / POSE mode
- Path: PICO POSE mode / 29-DoF G1 wrist-elbow mapping
- Network: PICO to dedicated 5 GHz router to the onboard Jetson. The stream was stable at ~90 FPS before the crash

### Additional context

I did not encounter this crash when running GR00T from an external PC. I observed it after moving the PICO teleop/deployment stack onboard to the G1 Jetson Orin NX.

After applying this local fix, I ran approximately 20 hours of real-robot teleoperation on G1 EDU across both POSE and PLANNER modes without seeing the PICO streamer crash again.

This PR is intended as a defensive guard to prevent the PICO streamer from crashing on invalid quaternion frames. It does not address the likely upstream/root cause that produces zero-norm or non-finite quaternions in the first place. Ideally, the underlying axis-angle/quaternion conversion path should also be investigated, especially around the warning:

```
RuntimeWarning: invalid value encountered in divide
  v = np.sin(angle / 2) * rotation_aa / angle
```