### PR TITLE
Add low-latency SONIC observation support

### DIFF
--- a/gear_sonic_deploy/policy/release/observation_config_low_latency.yaml
+++ b/gear_sonic_deploy/policy/release/observation_config_low_latency.yaml
@@ -1,0 +1,92 @@
+# SONIC Release (Low-Latency) - Observation Configuration
+# =======================================================
+# For ONNX models exported from the low-latency sonic_release checkpoint
+# (smpl 4-frame lookahead; g1/teleop lookahead at step1, body-frame orientation).
+#
+# Encoder input dimension: 1247   Decoder/policy dimension: 994   token: 64
+# Uses the unitoken_all_noz tokenizer config (3 encoders: g1, teleop, smpl)
+#
+# Requires the smpl_*_4frame_step1 entries in GetObservationRegistry()
+# (src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp) + a rebuild to load.
+
+observations:
+
+  - name: "token_state"
+    enabled: true
+
+  - name: "his_base_angular_velocity_10frame_step1"
+    enabled: true
+
+  - name: "his_body_joint_positions_10frame_step1"
+    enabled: true
+
+  - name: "his_body_joint_velocities_10frame_step1"
+    enabled: true
+
+  - name: "his_last_actions_10frame_step1"
+    enabled: true
+
+  - name: "his_gravity_dir_10frame_step1"
+    enabled: true
+
+encoder:
+  dimension: 64
+  use_fp16: false
+  encoder_observations:
+    # Shared
+    - name: "encoder_mode_4"
+      enabled: true
+    # g1 encoder: command_multi_future_nonflat (positions + velocities), step1
+    - name: "motion_joint_positions_10frame_step1"
+      enabled: true
+    - name: "motion_joint_velocities_10frame_step1"
+      enabled: true
+    # g1 encoder: motion_anchor_ori_b_mf_nonflat (body, multi-frame FIRST), step1
+    - name: "motion_anchor_orientation_10frame_step1"
+      enabled: true
+    # teleop encoder: motion_anchor_ori_b (body, single-frame SECOND)
+    - name: "motion_anchor_orientation"
+      enabled: true
+    # teleop encoder: command_multi_future_lower_body, step1
+    - name: "motion_joint_positions_lowerbody_10frame_step1"
+      enabled: true
+    - name: "motion_joint_velocities_lowerbody_10frame_step1"
+      enabled: true
+    # teleop encoder: vr_3point
+    - name: "vr_3point_local_target"
+      enabled: true
+    - name: "vr_3point_local_orn_target"
+      enabled: true
+    # smpl encoder: smpl_joints_multi_future_local_nonflat (4 frames, step1)  <-- LOW-LATENCY
+    - name: "smpl_joints_4frame_step1"
+      enabled: true
+    # smpl encoder: smpl_root_ori_b_multi_future (body, 4 frames, step1)      <-- LOW-LATENCY
+    - name: "smpl_anchor_orientation_4frame_step1"
+      enabled: true
+    # smpl encoder: joint_pos_multi_future_wrist_for_smpl (4 frames, step1)   <-- LOW-LATENCY
+    - name: "motion_joint_positions_wrists_4frame_step1"
+      enabled: true
+  encoder_modes:
+    - name: "g1"
+      mode_id: 0
+      required_observations:
+        - encoder_mode_4
+        - motion_joint_positions_10frame_step1
+        - motion_joint_velocities_10frame_step1
+        - motion_anchor_orientation_10frame_step1
+    - name: "teleop"
+      mode_id: 1
+      required_observations:
+        - encoder_mode_4
+        - motion_joint_positions_lowerbody_10frame_step1
+        - motion_joint_velocities_lowerbody_10frame_step1
+        - vr_3point_local_target
+        - vr_3point_local_orn_target
+        - motion_anchor_orientation
+    - name: "smpl"
+      mode_id: 2
+      required_observations:
+        - encoder_mode_4
+        - smpl_joints_4frame_step1
+        - smpl_anchor_orientation_4frame_step1
+        - motion_joint_positions_wrists_4frame_step1

--- a/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
+++ b/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
@@ -1738,6 +1738,7 @@ class G1Deploy {
               {"motion_joint_velocities_lowerbody_10frame_step1", 120, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointVelocitiesMultiFrame(buf, offset, 10, 1, lower_body_joint_mujoco_order_in_isaaclab_index); }},
               {"motion_joint_positions_wrists_10frame_step1", 60, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointPositionsMultiFrame(buf, offset, 10, 1, wrist_joint_isaaclab_order_in_isaaclab_index); }},
               {"motion_joint_positions_wrists_2frame_step1", 12, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointPositionsMultiFrame(buf, offset, 2, 1, wrist_joint_isaaclab_order_in_isaaclab_index); }},
+              {"motion_joint_positions_wrists_4frame_step1", 24, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointPositionsMultiFrame(buf, offset, 4, 1, wrist_joint_isaaclab_order_in_isaaclab_index); }},  // low-latency SONIC (smpl 4-frame)
               {"motion_joint_velocities_wrists_10frame_step1", 60, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointVelocitiesMultiFrame(buf, offset, 10, 1, wrist_joint_isaaclab_order_in_isaaclab_index); }},
               {"motion_joint_positions_5frame_step5", 145, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointPositionsMultiFrame(buf, offset, 5, 5); }},
               {"motion_joint_velocities_5frame_step5", 145, [this](std::vector<double>& buf, size_t offset) { return GatherMotionJointVelocitiesMultiFrame(buf, offset, 5, 5); }},
@@ -1747,7 +1748,8 @@ class G1Deploy {
               {"smpl_joints_10frame_step5", 720, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplJointsMultiFrame(buf, offset, 10, 5); }},  // 24*3*10
               {"smpl_joints_10frame_step1", 720, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplJointsMultiFrame(buf, offset, 10, 1); }},  // 24*3*10
               {"smpl_joints_lower_10frame_step1", 270, [this](std::vector<double>& buf, size_t offset) {return GatherMotionSmplJointsMultiFrame(buf, offset, 10, 1, {0,1,2,4,5,7,8,10,11}); }},  // 9*3*10 lower body joints
-              {"smpl_joints_2frame_step1", 144, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplJointsMultiFrame(buf, offset, 2, 1); }},  // 24*3*10
+              {"smpl_joints_2frame_step1", 144, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplJointsMultiFrame(buf, offset, 2, 1); }},  // 24*3*2
+              {"smpl_joints_4frame_step1", 288, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplJointsMultiFrame(buf, offset, 4, 1); }},  // 24*3*4, low-latency SONIC
               {"smpl_pose", 63, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplPosesMultiFrame(buf, offset, 1, 1); }},  // 21*3
               {"smpl_pose_5frame_step5", 315, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplPosesMultiFrame(buf, offset, 5, 5); }},  // 21*3*5
               {"smpl_pose_10frame_step5", 630, [this](std::vector<double>& buf, size_t offset) { return GatherMotionSmplPosesMultiFrame(buf, offset, 10, 5); }},  // 21*3*10
@@ -1756,6 +1758,7 @@ class G1Deploy {
               {"smpl_root_z_10frame_step1", 10, [this](std::vector<double>& buf, size_t offset) { return GatherMotionRootZPositionMultiFrame(buf, offset, 10, 1); }},
               {"smpl_anchor_orientation_10frame_step1", 60, [this](std::vector<double>& buf, size_t offset) { return GatherMotionAnchorOrientationMutiFrame(buf, offset, 10, 1); }},
               {"smpl_anchor_orientation_2frame_step1", 12, [this](std::vector<double>& buf, size_t offset) { return GatherMotionAnchorOrientationMutiFrame(buf, offset, 2, 1); }},
+              {"smpl_anchor_orientation_4frame_step1", 24, [this](std::vector<double>& buf, size_t offset) { return GatherMotionAnchorOrientationMutiFrame(buf, offset, 4, 1); }},  // low-latency SONIC (smpl 4-frame)
               // SMPL heading-only variants (mode=1, matches Python smpl_root_ori_heading_multi_future)
               {"smpl_anchor_orientation_heading_10frame_step1", 60, [this](std::vector<double>& buf, size_t offset) { return GatherMotionAnchorOrientationMutiFrame(buf, offset, 10, 1, 1); }},
               {"smpl_anchor_orientation_heading_2frame_step1", 12, [this](std::vector<double>& buf, size_t offset) { return GatherMotionAnchorOrientationMutiFrame(buf, offset, 2, 1, 1); }},


### PR DESCRIPTION
Enable the low-latency 3-point SONIC checkpoint (smpl 4-frame lookahead) in gear_sonic_deploy.

- Register the smpl 4-frame lookahead observations in GetObservationRegistry() so the low-latency encoder ONNX can load: smpl_joints_4frame_step1 (288) smpl_anchor_orientation_4frame_step1 (24) motion_joint_positions_wrists_4frame_step1 (24)
- Add policy/release/observation_config_low_latency.yaml (encoder obs_dict = 1247, decoder/policy obs_dict = 994, token = 64).

The new registry entries are inert unless referenced by an obs config, and the new config is opt-in via --obs-config, so existing deploys are unaffected. Also corrects a stale dimension comment on the existing smpl_joints_2frame_step1 entry (24*3*10 -> 24*3*2).