### PR TITLE
Fix DDS init on modern kernels: idempotent ChannelFactory.Init + relax cyclonedds pin

### DIFF
--- a/external_dependencies/unitree_sdk2_python/setup.py
+++ b/external_dependencies/unitree_sdk2_python/setup.py
@@ -14,7 +14,7 @@ setup(name='unitree_sdk2py',
       },
       python_requires='>=3.8',
       install_requires=[
-            "cyclonedds==0.10.2",
+            "cyclonedds>=0.10.2,<12",
             "numpy",
             "opencv-python",
       ],

--- a/external_dependencies/unitree_sdk2_python/unitree_sdk2py/core/channel.py
+++ b/external_dependencies/unitree_sdk2_python/unitree_sdk2py/core/channel.py
@@ -196,6 +196,13 @@ class ChannelFactory(Singleton):
         super().__init__()
 
     def Init(self, id: int, networkInterface: str = None, qos: Qos = None):
+        # Idempotent: the factory is a Singleton, and re-creating the Domain for
+        # the same process raises on cyclonedds >= 11 ("Occurred upon
+        # initialisation of a cyclonedds.domain.Domain"). gear_sonic initializes
+        # from both the control loop and the simulator in one process, so a
+        # second Init with an already-live domain must be a no-op.
+        if self.__domain is not None:
+            return True
         config = None
         # choose config
         if networkInterface is None:


### PR DESCRIPTION
## Problem

On Ubuntu 24.04 (kernel 6.x), `gear_sonic/scripts/run_sim_loop.py` fails at DDS initialization in two stacked ways:

1. **cyclonedds 0.10.2 hangs.** The pinned `cyclonedds==0.10.2` wheel's `Domain` creation blocks indefinitely on recent kernels — the sim loop stalls at `ChannelFactoryInitialize` with no error output.

2. **Double init raises on cyclonedds ≥ 11.** After upgrading cyclonedds, a second failure surfaces: the sim loop initializes the channel factory from both the control-loop side and the simulator side of the same process, and cyclonedds ≥ 11 refuses to re-create a live Domain:

```python
from unitree_sdk2py.core.channel import ChannelFactoryInitialize
ChannelFactoryInitialize(0, 'lo')   # ok
ChannelFactoryInitialize(0, 'lo')   # [ChannelFactory] create domain error.
                                    # msg: Occurred upon initialisation of a cyclonedds.domain.Domain
```

## Fix

- `ChannelFactory.Init` returns early when the domain is already live — the class is already a `Singleton`, so a second `Init` in-process is safe to treat as a no-op.
- Relax the vendored SDK's pin to `cyclonedds>=0.10.2,<12`. The SDK runs unmodified against cyclonedds 11.x (verified: pub/sub on `rt/lowstate`/`rt/lowcmd`, channel factory init with explicit interface, on both Python 3.10 and 3.12).

## Tested

- Ubuntu 24.04, kernel 6.17, RTX 6000 Ada, Python 3.10 (`.venv_sim`)
- Double-init snippet above passes after the patch
- `run_sim_loop.py --no-enable-onscreen --enable-offscreen` boots past DDS init