### PR TITLE
TRTInference: support TensorRT 11 (guard removed precision/batch APIs)

### DIFF
--- a/gear_sonic_deploy/src/TRTInference/InferenceEngine.cpp
+++ b/gear_sonic_deploy/src/TRTInference/InferenceEngine.cpp
@@ -175,7 +175,13 @@ bool ConvertONNXToTRT(
     }
 
     // Create network
+#if NV_TENSORRT_MAJOR < 11
     const uint32_t explicitBatch = 1U << static_cast<uint32_t>( nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH );
+#else
+    // Explicit batch has been the only mode since TensorRT 10; the flag itself
+    // was removed in TensorRT 11.
+    const uint32_t explicitBatch = 0U;
+#endif
     auto network = std::unique_ptr<nvinfer1::INetworkDefinition>( builder->createNetworkV2( explicitBatch ) );
     if ( !network )
     {
@@ -262,9 +268,20 @@ bool ConvertONNXToTRT(
             }
             auto &sizes = options.shape_tensor_sizes.at( name );
 
+#if NV_TENSORRT_MAJOR < 11
             profile->setShapeValues( name, nvinfer1::OptProfileSelector::kMIN, std::get<0>( sizes ).data(), std::get<0>( sizes ).size());
             profile->setShapeValues( name, nvinfer1::OptProfileSelector::kOPT, std::get<1>( sizes ).data(), std::get<1>( sizes ).size() );
             profile->setShapeValues( name, nvinfer1::OptProfileSelector::kMAX, std::get<2>( sizes ).data(), std::get<2>( sizes ).size() );
+#else
+            // TensorRT 11 removed setShapeValues; setShapeValuesV2 takes int64_t.
+            const auto toI64 = []( const std::vector<int> &v ) { return std::vector<int64_t>( v.begin(), v.end() ); };
+            const auto mins = toI64( std::get<0>( sizes ) );
+            const auto opts = toI64( std::get<1>( sizes ) );
+            const auto maxs = toI64( std::get<2>( sizes ) );
+            profile->setShapeValuesV2( name, nvinfer1::OptProfileSelector::kMIN, mins.data(), static_cast<int32_t>( mins.size() ) );
+            profile->setShapeValuesV2( name, nvinfer1::OptProfileSelector::kOPT, opts.data(), static_cast<int32_t>( opts.size() ) );
+            profile->setShapeValuesV2( name, nvinfer1::OptProfileSelector::kMAX, maxs.data(), static_cast<int32_t>( maxs.size() ) );
+#endif
         }
     }
 
@@ -279,6 +296,7 @@ bool ConvertONNXToTRT(
     // Set the precision level
     if ( options.precision == Precision::FP16 )
     {
+#if NV_TENSORRT_MAJOR < 11
         // Ensure the GPU supports FP16 inference
         if ( !builder->platformHasFastFp16() )
         {
@@ -286,6 +304,12 @@ bool ConvertONNXToTRT(
             return false;
         }
         config->setFlag( nvinfer1::BuilderFlag::kFP16 );
+#else
+        // TensorRT 11 removed BuilderFlag::kFP16 and platformHasFastFp16()
+        // (precision builder flags were superseded by strongly-typed
+        // networks); the engine builds with the precision expressed by the
+        // network itself.
+#endif
     }
 
     // CUDA stream used for profiling by the builder.


### PR DESCRIPTION
## Problem

TensorRT 11 (CUDA 13) removed several APIs `gear_sonic_deploy/src/TRTInference` uses, so the deploy stack no longer builds on current workstations:

- `BuilderFlag::kFP16` and `IBuilder::platformHasFastFp16` (precision builder flags superseded by strongly-typed networks)
- `NetworkDefinitionCreationFlag::kEXPLICIT_BATCH` (explicit batch is the only mode since TRT 10; the flag was deleted in 11)
- `IOptimizationProfile::setShapeValues` (replaced by `setShapeValuesV2`, which takes `int64_t` values)

## Fix

All four uses are version-guarded on `NV_TENSORRT_MAJOR`. Behavior on TensorRT ≤ 10 is unchanged.

## Verified

TensorRT 11.0.0 / CUDA 13.2, Ubuntu 24.04, RTX 6000 Ada:
- `model_decoder.onnx` and `model_encoder.onnx` (from `nvidia/GEAR-SONIC`) convert and build engines
- `g1_deploy_onnx_ref` runs against the MuJoCo sim (`run_sim_loop.py`) with `rt/lowcmd` at the full 500 Hz command rate

## Known limitation (independent of this patch)

`planner_sonic.onnx` does not convert on TensorRT 11 — the optimizer rejects a fused `mmm_net` node with `IShuffleLayer: input type Float, output type Int32`. Filed separately with details; the planner is optional (omit `--planner-file`) and the VLA latent path is unaffected.