### PR TITLE
Fix/ppo gc oom tradeoff

### DIFF
--- a/gear_sonic/trl/trainer/ppo_trainer.py
+++ b/gear_sonic/trl/trainer/ppo_trainer.py
@@ -1910,8 +1910,10 @@ class TRLPPOTrainer(PPOTrainer):  # noqa: F405
             self.lr_scheduler.step()
 
             del metrics, rollout_data
-            gc.collect()
-            torch.cuda.empty_cache()
+            # Skip pre-iteration GC here; motion loading performs fallback cleanup,
+            # which avoids extra synchronization overhead and improves training speed.
+            # gc.collect()
+            # torch.cuda.empty_cache()
 
             self.control = self.callback_handler.on_step_end(args, self.state, self.control)
 

--- a/gear_sonic/trl/trainer/ppo_trainer.py
+++ b/gear_sonic/trl/trainer/ppo_trainer.py
@@ -305,16 +305,17 @@ def process_ep_infos(ep_infos, device):
     """
     infos = {}
     for key in ep_infos[0]:
-        infotensor = torch.tensor([], device=device)
+        # Buffer tensors in Python and concatenate once to avoid filling allocator buckets with mismatched sizes.
+        values = []
         for ep_info in ep_infos:
-            # handle scalar and zero dimensional tensor infos
-            if not isinstance(ep_info[key], torch.Tensor):
-                ep_info[key] = torch.Tensor([ep_info[key]])
-            if len(ep_info[key].shape) == 0:
-                ep_info[key] = ep_info[key].unsqueeze(0)
-            infotensor = torch.cat((infotensor, ep_info[key].to(device)))
-        value = torch.mean(infotensor)
-        infos[key] = value
+            v = ep_info[key]
+            if not isinstance(v, torch.Tensor):
+                v = torch.tensor([v], device=device)
+            else:
+                if v.dim() == 0: v = v.unsqueeze(0)
+                if v.device != device: v = v.to(device)
+            values.append(v)
+        infos[key] = torch.cat(values).mean()
     return infos
 
 
@@ -2026,8 +2027,17 @@ class TRLPPOTrainer(PPOTrainer):  # noqa: F405
                     "train", start_time, num_tokens=self.state.num_input_tokens_seen
                 )
 
-        output = {**logs, **{"step": self.state.global_step}}  # noqa: PIE800
-        self.state.log_history.append(output)
+        # Sanitize all caller logs at this boundary: rank 0 stores only detached CPU/Python values.
+        if self.state.is_world_process_zero:
+            output = {}
+            for key, value in logs.items():
+                if isinstance(value, torch.Tensor):
+                    value = value.detach().cpu().item()
+                elif isinstance(value, np.ndarray):
+                    value = float(value)
+                output[key] = value
+            output["step"] = self.state.global_step
+            self.state.log_history.append(output)
 
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/gear_sonic/utils/motion_lib/motion_lib_base.py
+++ b/gear_sonic/utils/motion_lib/motion_lib_base.py
@@ -1593,8 +1593,6 @@ class MotionLibBase:
             _motion_object_root_pos,
             _motion_object_root_quat,
         )
-        gc.collect()
-        torch.cuda.empty_cache()
 
         if "mujoco_to_isaaclab_body" in self.m_cfg.keys():  # noqa: SIM118
             self.dof_pos = self.dof_pos[:, self.m_cfg.mujoco_to_isaaclab_dof]
@@ -1624,6 +1622,10 @@ class MotionLibBase:
             self.body_lin_vel_w_full = self.body_lin_vel_w
             self.body_ang_vel_w_full = self.body_ang_vel_w
             self.num_bodies_full = self.body_pos_w.shape[2]
+
+        # Run cleanup after slicing so temporary fragments do not live through the next cycle.
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def foot_detect(self, positions, vel_thres, height_thresh):
         fid_l = self.m_cfg.get("left_foot_body_idx", [6])


### PR DESCRIPTION
## Summary

This PR resolves the trade-off between PPO iteration speed and CUDA OOM risk.

Previously, running GC and `torch.cuda.empty_cache()` every PPO iteration helped avoid OOM, but introduced significant synchronization overhead and slowed training. Removing that per-iteration cleanup improved iteration speed, but exposed OOM issues from retained GPU references and allocator fragmentation.

This PR keeps the faster PPO iteration path while preventing OOM by:
- Aggregating episode info tensors with Python lists and a single `torch.cat()` per key, reducing allocator churn from repeated concatenation.
- Sanitizing logs at the `Trainer.log()` boundary so `log_history` stores only detached CPU/Python values on rank 0.
- Moving motion-lib GC/cache cleanup after body slicing, so temporary slicing fragments are released before the next training cycle.

## Motivation

The goal is to avoid expensive GC on every PPO iteration while still keeping GPU memory stable across training cycles.

## Acknowledgements

This PR was implemented by the contributor. Special thanks to Sarah from the NVIDIA team for testing and validation support.