### PR TITLE
perf(sonic): skip log history when copying checkpoint state

### DIFF
--- a/gear_sonic/trl/callbacks/model_save_callback.py
+++ b/gear_sonic/trl/callbacks/model_save_callback.py
@@ -120,8 +120,9 @@ class ModelSaveCallback(TrainerCallback):
     ):
         if model is not None:
             # Save model, optimizer, scheduler and training state
-            _state = copy.deepcopy(state)
-            _state.__dict__.pop("log_history")
+            state_without_log_history = copy.copy(state)
+            state_without_log_history.__dict__.pop("log_history")
+            _state = copy.deepcopy(state_without_log_history)
             checkpoint = {
                 "policy_state_dict": model.policy.state_dict(),
                 "value_state_dict": (


### PR DESCRIPTION
## Summary

- Make a shallow copy of `TrainerState` before checkpoint serialization.
- Remove `log_history` from that shallow copy before performing the expensive deep copy.
- Keep the live `TrainerState` untouched.
- Preserve the existing checkpoint format, which already excludes `log_history`.

## Motivation

`TrainerState.log_history` grows once per training iteration. The previous implementation deep-copied the full history and removed it only from the completed copy:

```python
state_copy = copy.deepcopy(state)
state_copy.__dict__.pop("log_history")
```

That makes checkpoint preparation scale linearly with global step even though the copied history is immediately discarded.

The new order is:

```python
state_without_log_history = copy.copy(state)
state_without_log_history.__dict__.pop("log_history")
state_copy = copy.deepcopy(state_without_log_history)
```

This avoids mutating the live state, changing its attribute order, or exposing a temporarily incomplete object to another reader.

## Validation

The callback test uses a real `TrainerState` and the real `ModelSaveCallback` path while intercepting only `torch.save()`.

It verifies that:

- persisted state is identical to the old implementation;
- persisted state still excludes `log_history`;
- the live state and original history-list identity remain unchanged;
- attribute order remains unchanged;
- a `deepcopy()` exception does not alter the live state.

Synthetic benchmark using a real `TrainerState` and seven repetitions per case (median reported):

| History entries | `copy.copy` only | `copy.deepcopy` only | Previous checkpoint path | Candidate checkpoint path |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 0.034 ms | 0.068 ms | 0.066 ms | 0.070 ms |
| 50 | 0.032 ms | 0.546 ms | 0.545 ms | 0.071 ms |
| 100 | 0.034 ms | 1.025 ms | 1.015 ms | 0.072 ms |
| 500 | 0.034 ms | 4.814 ms | 4.877 ms | 0.081 ms |
| 2000 | 0.036 ms | 18.437 ms | 18.612 ms | 0.074 ms |
| 10000 | 0.036 ms | 97.028 ms | 98.662 ms | 0.071 ms |
| 30000 | 0.036 ms | 298.629 ms | 308.281 ms | 0.074 ms |

These local absolute times use lightweight synthetic entries and demonstrate the complexity change, not production checkpoint latency.


A downstream long-run report measured an approximately 2.094 ms/entry slope over 50-500 entries. The reported 63 seconds per save at step 30k and five minutes per 250-iteration window are extrapolations from that measured slope, not direct step-30k measurements.

`git diff --check` and Python syntax compilation pass.

## Scope

This PR removes the unnecessary checkpoint deep-copy cost. It does not bound `log_history`, convert logged CUDA tensors to host scalars, or address CUDA-memory retention caused by live tensor references. Those are separate issues.
