### PR TITLE
documentation: Updating the Camera Televiz Instructions

### DIFF
--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -106,36 +106,51 @@ Watch the streamer logs for `Isaac Teleop session initialized.` — that means C
 
 For controls and calibration, see [VR Whole-Body Teleop](vr_wholebody_teleop.md#pico-controls).
 
-## Step 6: Start Camera Streaming
+## Step 6: Start Camera Visualization
 
-Stream cameras to the headset via upstream IsaacTeleop's `camera_streamer.sh`. If you don't have the IsaacTeleop repo yet, clone it first:
+Stream cameras to the headset via upstream IsaacTeleop's `camera_viz.sh`. If you don't have the IsaacTeleop repo yet, clone it first:
 
 ```bash
 git clone --recurse-submodules https://github.com/NVIDIA/IsaacTeleop.git
 ```
 
-Then build and launch the camera streamer:
+Then create the environment for the camera visualization streamer:
 
 ```bash
-cd IsaacTeleop
-cd examples/camera_streamer
-
-./camera_streamer.sh build
-./camera_streamer.sh list-cameras
+  cd IsaacTeleop
+  examples/camera_viz/camera_viz.sh setup
+  source examples/camera_viz/.venv/bin/activate
+```
+### Optional: Camera Preview in a Window
+If you have video preview available such as on Thor or desktop simulation, it might be best to test your camera first with the "window" mode:
+```bash
+   ./camera_viz.sh run configs/YOUR_CAMERA.yaml --mode window
 ```
 
-Run with local cameras streaming to the XR headset:
+Choosing the correct yaml configuration camera for your setup is critical. The v4l2.yaml configuration is default but other configs are available:
+```bash
+   ./camera_viz.sh run configs/v4l2.yaml --mode window
+   ./camera_viz.sh run configs/v4l2-realsense.yaml --mode window
+   ./camera_viz.sh run configs/oakd.yaml --mode window
+   ./camera_viz.sh run configs/zed.yaml --mode window
+```
+If you do not see correct output for your camera, you may need to modify the closest yaml file to your setup or create your own in the configs folder. Consider the following:
+- Having more than one camera connected will modify what channel the video should be served from.
+- First, try the command "lsusb" to see if your camera is connected.
+- Next, use "ls -1 /dev/video* to list all video device modes.
+- If you are using a v4l2 setup these cammands will help to debug what is possible:
+  - To see the association of channels to cameras: "v4l2-ctl --list-devices"
+  - For each node, see what it captures and in what pixel formats: "v4l2-ctl --device=/dev/video0 --list-formats"
+  - To see full details on formats and available resolutions:  "v4l2-ctl --device=/dev/video0 --list-formats-ext"
+Once you have this information, make sure the settings in your yaml config match.
+
+### Final Camera Streaming Command
+
+Once you are certain you have valid yaml configured, shut down any preview windows and run instead with "--mode xr", which will stream frames to Isaac Teleop:
 
 ```bash
-source scripts/setup_cloudxr_env.sh
-./camera_streamer.sh run --source local --mode xr
-
-# Optionally specify a camera configuration:
-#   --config config/single_camera.yaml
-#   --config config/multi_camera.yaml
+   ./camera_viz.sh run configs/YOUR_CAMERA.yaml --mode xr
 ```
-
-The `--input-source isaac-teleop` flag also works with [Data Collection](data_collection.md).
 
 ## Troubleshooting
 

--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -104,7 +104,7 @@ python gear_sonic/scripts/pico_manager_thread_server.py --manager \
 
 Watch the streamer logs for `Isaac Teleop session initialized.` — that means CloudXR + DeviceIO are both up. The streamer then prints `Manager controls: A+X=toggle mode, A+B+X+Y=start/stop policy` once the headset is connected and body data starts flowing.
 
-For controls and calibration, see [VR Whole-Body Teleop](#pico-controls).
+For controls and calibration, see [VR Whole-Body Teleop](vr_wholebody_teleop.md#pico-controls).
 
 ## Step 6: Start Camera Visualization
 

--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -146,13 +146,14 @@ If you do not see correct output for your camera, you may need to modify the clo
   - To see full details on formats and available resolutions:  "v4l2-ctl --device=/dev/video0 --list-formats-ext"
 Once you have this information, make sure the settings in your yaml config match.
 
-### Final Camera Streaming Command
+### XR Camera Streaming Command
 
 Once you are certain you have valid yaml configured, shut down any preview windows and run instead with "--mode xr", which will stream frames to Isaac Teleop:
 
 ```bash
 ./camera_viz.sh run configs/[YOUR_CAMERA].yaml --mode xr
 ```
+This should also be consistent with the [instructions found at IsaacTeleop](https://nvidia.github.io/IsaacTeleop/main/references/camera_streaming.html).
 
 ## Troubleshooting
 

--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -104,7 +104,7 @@ python gear_sonic/scripts/pico_manager_thread_server.py --manager \
 
 Watch the streamer logs for `Isaac Teleop session initialized.` — that means CloudXR + DeviceIO are both up. The streamer then prints `Manager controls: A+X=toggle mode, A+B+X+Y=start/stop policy` once the headset is connected and body data starts flowing.
 
-For controls and calibration, see [VR Whole-Body Teleop](vr_wholebody_teleop.md#pico-controls).
+For controls and calibration, see [VR Whole-Body Teleop](#pico-controls).
 
 ## Step 6: Start Camera Visualization
 
@@ -117,28 +117,30 @@ git clone --recurse-submodules https://github.com/NVIDIA/IsaacTeleop.git
 Then create the environment for the camera visualization streamer:
 
 ```bash
-  cd IsaacTeleop
-  examples/camera_viz/camera_viz.sh setup
-  source examples/camera_viz/.venv/bin/activate
+cd IsaacTeleop
+examples/camera_viz/camera_viz.sh setup
+source examples/camera_viz/.venv/bin/activate
+cd examples/camera_viz
 ```
 ### Optional: Camera Preview in a Window
 If you have video preview available such as on Thor or desktop simulation, it might be best to test your camera first with the "window" mode:
 ```bash
-   ./camera_viz.sh run configs/YOUR_CAMERA.yaml --mode window
+./camera_viz.sh run configs/YOUR_CAMERA.yaml --mode window
 ```
 
 Choosing the correct yaml configuration camera for your setup is critical. The v4l2.yaml configuration is default but other configs are available:
 ```bash
-   ./camera_viz.sh run configs/v4l2.yaml --mode window
-   ./camera_viz.sh run configs/v4l2-realsense.yaml --mode window
-   ./camera_viz.sh run configs/oakd.yaml --mode window
-   ./camera_viz.sh run configs/zed.yaml --mode window
+# run just one of these that best matches your camera
+./camera_viz.sh run configs/v4l2.yaml --mode window
+./camera_viz.sh run configs/oakd.yaml --mode window
+./camera_viz.sh run configs/zed.yaml --mode window
+./camera_viz.sh run configs/realsense.yaml --mode window
 ```
 If you do not see correct output for your camera, you may need to modify the closest yaml file to your setup or create your own in the configs folder. Consider the following:
 - Having more than one camera connected will modify what channel the video should be served from.
 - First, try the command "lsusb" to see if your camera is connected.
 - Next, use "ls -1 /dev/video* to list all video device modes.
-- If you are using a v4l2 setup these cammands will help to debug what is possible:
+- If you are using a v4l2 setup (Video4Linux2), these cammands will help to debug what is possible:
   - To see the association of channels to cameras: "v4l2-ctl --list-devices"
   - For each node, see what it captures and in what pixel formats: "v4l2-ctl --device=/dev/video0 --list-formats"
   - To see full details on formats and available resolutions:  "v4l2-ctl --device=/dev/video0 --list-formats-ext"
@@ -149,7 +151,7 @@ Once you have this information, make sure the settings in your yaml config match
 Once you are certain you have valid yaml configured, shut down any preview windows and run instead with "--mode xr", which will stream frames to Isaac Teleop:
 
 ```bash
-   ./camera_viz.sh run configs/YOUR_CAMERA.yaml --mode xr
+./camera_viz.sh run configs/[YOUR_CAMERA].yaml --mode xr
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Recently we have simplified the operating process for connecting a camera to televiz after this change to IsaacTeleop:
`https://github.com/NVIDIA/IsaacTeleop/pull/720/changes`
I plan to update the recommended instructions at `https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/isaac_teleop_publisher_setup.html` to reflect this.
The documentation UI has been rebuilt and tested for errors.