### PR TITLE
deploy: add --deploy-yes flag to skip the confirmation prompt

### DIFF
--- a/gear_sonic_deploy/deploy.sh
+++ b/gear_sonic_deploy/deploy.sh
@@ -211,6 +211,7 @@ show_usage() {
     echo "  --input-type TYPE       Set the input type (default: zmq_manager)"
     echo "  --output-type TYPE      Set the output type (default: ros2)"
     echo "  --zmq-host HOST         Set the ZMQ host (default: localhost)"
+    echo "  --deploy-yes            Skip the 'Proceed with deployment?' prompt (auto-confirm)"
     echo ""
     echo "Interface modes:"
     echo "  sim              Use loopback interface for simulation (MuJoCo)"
@@ -251,6 +252,7 @@ MOTION_DATA="$MOTION_DATA_DEFAULT"
 INPUT_TYPE="$INPUT_TYPE_DEFAULT"
 OUTPUT_TYPE="$OUTPUT_TYPE_DEFAULT"
 ZMQ_HOST="$ZMQ_HOST_DEFAULT"
+AUTO_YES=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -314,6 +316,10 @@ while [[ $# -gt 0 ]]; do
             fi
             ZMQ_HOST="$2"
             shift 2
+            ;;
+        --deploy-yes)
+            AUTO_YES=true
+            shift
             ;;
         sim|real)
             INTERFACE_MODE="$1"
@@ -544,7 +550,12 @@ else
     echo -e "${YELLOW}📋 This will start the simulation control system.${NC}"
 fi
 echo ""
-read -p "$(echo -e ${GREEN}Proceed with deployment? [Y/n]: ${NC})" confirm
+if [[ "$AUTO_YES" == "true" ]]; then
+    confirm="y"
+    echo -e "${GREEN}Proceed with deployment? [Y/n]: y (auto-confirmed via --deploy-yes)${NC}"
+else
+    read -p "$(echo -e ${GREEN}Proceed with deployment? [Y/n]: ${NC})" confirm
+fi
 
 if [[ "$confirm" =~ ^[Yy]$ ]] || [[ -z "$confirm" ]]; then
     echo ""


### PR DESCRIPTION
## Summary
Adds an opt-in `--deploy-yes` flag to `gear_sonic_deploy/deploy.sh` that auto-confirms the `Proceed with deployment? [Y/n]` prompt, for non-interactive / scripted starts. This prompt was making it a difficult user experience to start a multi-terminal/multi-process stack since this was the only process that requires user input after the execution was started. Here is an example of the prompt in action:
<img width="988" height="1332" alt="image" src="https://github.com/user-attachments/assets/54ea6e91-fe56-4747-9c0b-2be2e9dbf210" />


## Details
- New `--deploy-yes` flag wired into the argument parser (documented in `--help`).
- When set, the confirmation is auto-answered `y`; otherwise the prompt behaves exactly as before.
- Only the `read` prompt is skipped — stdin is left intact, so in-terminal controls (e.g. emergency stop) continue to work.

## Backward compatibility
Default behavior is unchanged: without the flag, `deploy.sh` still prompts. Safe for `real` runs where confirmation is desirable.

## Usage
```bash
./deploy.sh --input-type zmq_manager sim --deploy-yes
```