### PR TITLE
pico_manager: throttle + timestamp the Isaac Teleop waiting message

### DIFF
--- a/gear_sonic/scripts/pico_manager_thread_server.py
+++ b/gear_sonic/scripts/pico_manager_thread_server.py
@@ -1574,8 +1574,16 @@ def _init_input_source(
         reader = input_readers.IsaacTeleopReader(max_queue_size=buffer_size)
         reader.start()
         print("Using Isaac Teleop (in-process CloudXR / DeviceIO), waiting for data...")
+        # Check for data every second so the connection is detected promptly, but
+        # only print the waiting message every 5th iteration (~5s) to reduce spam.
+        wait_iterations = 0
         while reader.get_latest() is None:
-            print("waiting for Isaac Teleop body data (connect the headset to CloudXR)...")
+            if wait_iterations % 5 == 0:
+                print(
+                    f"[{time.strftime('%H:%M:%S')}] waiting for Isaac Teleop body data "
+                    "(connect the headset to CloudXR)..."
+                )
+            wait_iterations += 1
             time.sleep(1)
         return reader
 


### PR DESCRIPTION
## Summary
While `pico_manager_thread_server.py --input-source isaac-teleop` waits for the headset to connect, it printed `waiting for Isaac Teleop body data (connect the headset to CloudXR)...` **every second**, which floods the terminal.

## Changes
- **~5x less frequent:** the message now prints every 5th loop iteration (~5s). The loop still polls `reader.get_latest()` every second, so the connection is still detected promptly (no added latency).
- **Timestamp:** each message is prefixed with `[HH:MM:SS]` so successive lines convey the passage of time while waiting.

## Example
```
Using Isaac Teleop (in-process CloudXR / DeviceIO), waiting for data...
[14:23:05] waiting for Isaac Teleop body data (connect the headset to CloudXR)...
[14:23:10] waiting for Isaac Teleop body data (connect the headset to CloudXR)...
```

## Scope
Only the `isaac-teleop` waiting loop is changed; behavior is otherwise unchanged.