### PR TITLE
fix: Make ONNX export use a deterministic tokenizer-observation order

### DIFF
--- a/gear_sonic/utils/inference_helpers.py
+++ b/gear_sonic/utils/inference_helpers.py
@@ -95,7 +95,11 @@ def export_universal_token_module_as_onnx(
     encoder_tokenizer_obs = [f for f in encoder_input_features if f not in special_keys]
     decoder_tokenizer_obs = [f for f in decoder_input_features if f not in special_keys]
 
-    required_tokenizer_obs = list(set(encoder_tokenizer_obs + decoder_tokenizer_obs))
+    # required_tokenizer_obs = list(set(encoder_tokenizer_obs + decoder_tokenizer_obs))
+    required_set = set(encoder_tokenizer_obs + decoder_tokenizer_obs)
+    required_tokenizer_obs = [
+        name for name in module.tokenizer_obs_names if name in required_set
+    ]
 
     # Calculate total input dimension
     total_feature_dim = 0


### PR DESCRIPTION
## Summary

- Make ONNX export use a deterministic tokenizer-observation order.
- Replace `list(set(...))` with a stable order derived from `module.tokenizer_obs_names`.
- Keep the exported input shape unchanged.
- Preserve the existing deploy input contract:

```text
[ tokenizer observations | proprioception ]
```

## Motivation

The previous ONNX export path collected required tokenizer observations with:

```python
required_tokenizer_obs = list(set(encoder_tokenizer_obs + decoder_tokenizer_obs))
```

`set` does not preserve order. Across different Python processes, `PYTHONHASHSEED` values, or runtime environments, the same feature set can be materialized in different orders.

For the `g1` export, the required tokenizer observations can appear as:

```python
["command_multi_future_nonflat", "motion_anchor_ori_b_mf_nonflat"]
```

or as:

```python
["motion_anchor_ori_b_mf_nonflat", "command_multi_future_nonflat"]
```

Both layouts produce the same total ONNX input shape, so the exported model still accepts an input of shape `[1, 1570]`. However, the internal slicing semantics become different.

The intended deploy input layout is:

```text
[ command_multi_future_nonflat(580) | motion_anchor_ori_b_mf_nonflat(60) | proprioception(930) ]
```

If export uses the reversed tokenizer-observation order, the ONNX graph slices the same input as:

```text
[ motion_anchor_ori_b_mf_nonflat(60) | command_multi_future_nonflat(580) | proprioception(930) ]
```

This does not fail at runtime because the shape is still valid, but the feature semantics are wrong and the resulting action can differ significantly.

The new implementation keeps `set` only for membership lookup and restores deterministic ordering from the module schema:

```python
required_set = set(encoder_tokenizer_obs + decoder_tokenizer_obs)
required_tokenizer_obs = [
    name for name in module.tokenizer_obs_names if name in required_set
]
```

## Validation

Using the old export logic, the same checkpoint was exported three times. The generated `model_step_XXXXXX_g1.onnx` files were saved as `model1.onnx`, `model2.onnx`, and `model3.onnx`.

A fixed initial deploy input was used to compare model outputs. `model1` produced different actions, while `model2` and `model3` matched.

The ONNX file hashes also showed that not all exports were identical:

```text
model1  31791ecf3ba03527598ec2662266523ee778cdcdda53d3ff8ce0d6dc55e4b84b
model2  a2c4958493ce107abc1724edcc6d4934d5674e19e34b3da52239d32171d2e548
model3  a2c4958493ce107abc1724edcc6d4934d5674e19e34b3da52239d32171d2e548
```

This confirmed that repeated exports from the same checkpoint could produce different ONNX artifacts.

After applying the deterministic ordering fix, the same checkpoint was exported three more times as `model4.onnx`, `model5.onnx`, and `model6.onnx`.

All three exported models produced identical actions, and their hashes were identical:

```text
model4  a2c4958493ce107abc1724edcc6d4934d5674e19e34b3da52239d32171d2e548
model5  a2c4958493ce107abc1724edcc6d4934d5674e19e34b3da52239d32171d2e548
model6  a2c4958493ce107abc1724edcc6d4934d5674e19e34b3da52239d32171d2e548
```

Additional semantic validation confirmed the suspected ordering issue:

- Feeding the normal deploy input to `model1` and `model2`:

```text
max_abs=2.0189018, allclose=False
```

- Reordering the first 640 input dimensions for `model1` from:

```text
[580 future | 60 orientation]
```

to:

```text
[60 orientation | 580 future]
```

made `model1` exactly match `model2`:

```text
model1 reversed vs model2 max_abs=0.0, allclose=True
```

This shows that `model1` was consistent with the reversed tokenizer-observation order, while `model2` through `model6` used the stable deploy-compatible order.

The SMPL ONNX export path uses the same tokenizer-observation ordering logic and was validated in the same way. Repeated exports from the same checkpoint become stable after this change, with matching hashes and matching inference outputs for the same input.

## Scope

This PR only fixes nondeterministic tokenizer-observation ordering during ONNX export.

It does not change:

- model weights;
- checkpoint loading;
- ONNX input shape;
- deploy-side input construction;
- runtime inference code.

Existing ONNX files exported with the old `list(set(...))` logic may still have an incorrect tokenizer-observation order and should be re-exported.
