### PR TITLE
Modify Hugging Face CLI installation command

### DIFF
--- a/docs/source/getting_started/download_models.md
+++ b/docs/source/getting_started/download_models.md
@@ -170,7 +170,7 @@ and optional data exporter.
 If you prefer the Hugging Face CLI:
 
 ```bash
-pip install huggingface_hub[cli]
+python -m pip install -U "huggingface_hub[cli]"
 
 # Policy only
 hf download nvidia/GEAR-SONIC \


### PR DESCRIPTION
Updated installation command for Hugging Face CLI to use 'python -m pip install -U' for better compatibility.