### PR TITLE
docs: clarify CloudXR mobile Blackwell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python gear_sonic/scripts/launch_inference.py \
 
 SONIC supports real-time whole-body teleoperation via PICO VR headset, enabling natural human-to-robot motion transfer for data collection and interactive control.
 
-This repo can also drive the headset over Isaac Teleop / CloudXR by launching `gear_sonic/scripts/pico_manager_thread_server.py --input-source isaac-teleop`. The streamer hosts the CloudXR runtime in-process via `isaacteleop[cloudxr]` — no separate publisher container required. That path is currently documented and supported only for **G1 with a Thor backpack**. The Isaac Teleop bring-up steps are documented in [`docs/source/tutorials/isaac_teleop_publisher_setup.md`](docs/source/tutorials/isaac_teleop_publisher_setup.md).
+This repo can also drive the headset over Isaac Teleop / CloudXR by launching `gear_sonic/scripts/pico_manager_thread_server.py --input-source isaac-teleop`. The streamer hosts the CloudXR runtime in-process via `isaacteleop[cloudxr]` — no separate publisher container required. That path is currently documented and supported only for **G1 with a Thor backpack**. As of 07/08/2026, CloudXR 6.2.0 does not support mobile Blackwell GPUs, including GeForce RTX 50-series Laptop GPUs; desktop Blackwell support does not extend to the corresponding laptop variants. The Isaac Teleop bring-up steps and compatibility notes are documented in [`docs/source/tutorials/isaac_teleop_publisher_setup.md`](docs/source/tutorials/isaac_teleop_publisher_setup.md).
 
 <div align="center">
 <table>

--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -5,6 +5,8 @@ This page documents the Isaac Teleop / CloudXR bring-up for **G1 with a Thor bac
 ```{admonition} Scope
 :class: important
 This workflow is currently documented and supported only for **G1 + Thor backpack**.
+
+As of 07/08/2026, CloudXR 6.2.0 does not support mobile Blackwell GPUs, including GeForce RTX 50-series Laptop GPUs. Support for desktop Blackwell GPUs does not extend to the corresponding laptop variants. This restriction does not apply to the supported Jetson Thor path documented here.
 ```
 
 ## Prerequisites
@@ -139,6 +141,12 @@ The `--input-source isaac-teleop` flag also works with [Data Collection](data_co
 
 ## Troubleshooting
 
+### Streaming connection times out on a Blackwell laptop GPU
+
+The CloudXR client may time out after about 30 seconds with error `0xC0F22219`, while `cxr_streamsdk` reports that the GPU device ID is not white-listed. If the server uses a GeForce RTX 50-series Laptop GPU, this is a CloudXR 6.2.0 compatibility limitation: mobile Blackwell GPUs are not supported. Changing network settings or selecting a different codec will not enable the encoder. Use the supported G1 + Thor host described in this guide.
+
+Triage CloudXR compatibility reports first to the [NVIDIA/IsaacTeleop issue tracker](https://github.com/NVIDIA/IsaacTeleop/issues), because `isaacteleop[cloudxr]` packages and launches the runtime. Include the `isaacteleop` and CloudXR versions, full GPU model and PCI device ID, and the CloudXR logs. GPU allow-list and encoder enablement belong to the CloudXR runtime and cannot be fixed in `GR00T-WholeBodyControl`.
+
 ### `RuntimeError: Failed to get OpenXR system: -35`
 
 In this setup, that error usually means the XR client is not connected yet. Re-check:
@@ -167,4 +175,3 @@ The streamer logs `[IsaacTeleopReader] No DeviceIO data for 5.0s, flagging disco
 1. The headset is still connected to CloudXR (Step 3).
 2. The Pico body trackers are paired and calibrated (see [VR Teleop Setup → Motion Tracker Setup](../getting_started/vr_teleop_setup.md)).
 3. The first time the schema runs, watch for `[IsaacTeleopReader] Unrecognised body_data schema: type=...` — if you see it, the upstream `FullBodyTrackerPico.get_body_pose().data` shape changed and `_body_data_to_24x7()` in `gear_sonic/utils/teleop/input_readers.py` needs an extra branch for the new layout.
-


### PR DESCRIPTION
## Summary

- document that CloudXR 6.2.0 does not support mobile Blackwell GPUs, including GeForce RTX 50-series Laptop GPUs
- add troubleshooting guidance for the 30-second `0xC0F22219` timeout and GPU whitelist warning
- route CloudXR compatibility reports to NVIDIA/IsaacTeleop and clarify that runtime GPU enablement is outside this repository

## Scope

This is a documentation-only change. It does not add CloudXR support for mobile Blackwell GPUs.

Refs #206.

## Validation

- `git diff --check`
- Sphinx HTML build succeeded; it reports nine pre-existing documentation warnings unrelated to this change