### PR TITLE
Reject empty planner file paths

### DIFF
--- a/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
+++ b/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
@@ -4102,7 +4102,7 @@ int main(int argc, char const* argv[]) {
     std::cout << "  policy_file: path to ONNX policy file" << std::endl;
     std::cout << "  motion_data_path: path to motion data directory (e.g., reference/bones_072925_test/)" << std::endl;
     std::cout << "\nOptions:" << std::endl;
-    std::cout << "  --planner-file <path>: specify planner file (optional)" << std::endl;
+    std::cout << "  --planner-file <path>: specify a non-empty planner file (omit to disable planner)" << std::endl;
     std::cout << "  --input-type <keyboard|gamepad|gamepad_manager|manager|zmq|zmq_manager";
 #if HAS_ROS2
     std::cout << "|ros2";
@@ -4203,14 +4203,16 @@ int main(int argc, char const* argv[]) {
         exit(1);
       }
     } else if (std::string(argv[i]) == "--planner-file") {
-      if (i + 1 < argc) {
-        plannerFile = argv[i + 1];
-        std::cout << "[INFO] Using planner file: " << plannerFile << std::endl;
-        i++; // Skip the next argument since it's the planner path
-      } else {
-        std::cerr << "Error: --planner-file requires a path argument" << std::endl;
+      // Reject empty values and following options before they can be mistaken for
+      // a planner path. Some command wrappers discard quoted empty arguments.
+      if (i + 1 >= argc || argv[i + 1][0] == '\0' ||
+          std::strncmp(argv[i + 1], "--", 2) == 0) {
+        std::cerr << "Error: --planner-file requires a non-empty path argument" << std::endl;
         exit(1);
       }
+      plannerFile = argv[i + 1];
+      std::cout << "[INFO] Using planner file: " << plannerFile << std::endl;
+      i++; // Skip the next argument since it's the planner path
     } else if (std::string(argv[i]) == "--target-motion-logfile") {
       if (i + 1 < argc) {
         targetMotionLogfile = argv[i + 1];


### PR DESCRIPTION
## Summary

- reject missing or empty `--planner-file` values before deployment initialization
- reject a following `--...` option as the planner path, covering command wrappers that discard an empty argument
- clarify that omitting `--planner-file` is the supported way to disable the planner

## Why

An explicitly empty planner path can currently be accepted as planner-less operation. When the `just run` wrapper discards that empty argument, the parser instead consumes the following option as the planner path and reaches deployment initialization before failing.

This PR addresses only the command-line behavior described in issue #184; it does not address the TensorRT 11 conversion failure.

Related to https://github.com/NVlabs/GR00T-WholeBodyControl/issues/184. This PR intentionally does not close the issue because the TensorRT topic remains unresolved.

## Testing

- `git diff --check`
- focused C++ predicate smoke test covering missing, empty, following-option, and valid planner values
- full deployment build not run because the local environment does not include CMake/Just or the CUDA/TensorRT dependency stack
