### PR TITLE
Add live camera teleoperation example

### DIFF
--- a/gear_sonic/examples/live_camera_teleop/README.md
+++ b/gear_sonic/examples/live_camera_teleop/README.md
@@ -1,0 +1,82 @@
+# Live Camera Teleoperation with GEM-X
+
+Drive the Unitree G1 from a **live webcam** by feeding
+[GEM-X](https://github.com/NVlabs/GEM-X) 3D human pose estimation into GEAR-SONIC.
+No motion-capture suit or VR trackers; just a camera.
+
+GEM-X estimates full-body human motion (the SOMA body model); this example bridges
+that motion into SONIC's existing ZMQ streaming interface, and SONIC's policy
+tracks it while keeping balance.
+
+> GEM-X is an **optional external dependency** and is **not** bundled here. Install
+> it separately and point these scripts at it with `--gemx-root` (or `$GEMX_ROOT`).
+
+## How it works
+
+| Script(s) | SONIC protocol | SONIC encoder |
+|---|---|---|
+| `webcam_stream.py` + `soma_to_smpl.py` | v3 (SMPL) | `smpl` (mode 2) |
+| `soma_pt_to_sonic_v3.py` (offline verify) | v3 (SMPL) | `smpl` (mode 2) |
+
+GEM-X runs in a rolling-window loop producing SOMA per frame; `soma_to_smpl.py`
+converts SOMA (77 joints) -> SMPL (24 joints, root-local, gravity-aligned) and
+streams Protocol v3 so SONIC's learned `smpl` encoder does the human->robot
+mapping (no offline retargeter in the loop).
+
+## Prerequisites
+
+1. **SONIC deployment** built and runnable (see the repo Quick Start), with the
+   released policy that has the `smpl` encoder (`policy/release/`).
+2. **GEM-X** cloned and installed: https://github.com/NVlabs/GEM-X
+   (its checkpoints/assets download from HuggingFace on first run).
+3. Python deps in the environment you run these scripts in: `pyzmq`, `scipy`,
+   `numpy`, `opencv-python`, and a CUDA-matched `onnxruntime-gpu`.
+
+## Usage
+
+Run the SONIC deploy in ZMQ mode first (sim shown; use `real` for hardware):
+
+```bash
+# terminal 1 (repo root): MuJoCo sim
+python gear_sonic/scripts/run_sim_loop.py
+# terminal 2 (gear_sonic_deploy/): deploy, ZMQ input
+bash deploy.sh --input-type zmq --zmq-host localhost --zmq-port 5556 --zmq-topic pose --zmq-conflate sim
+```
+
+### Live webcam (Protocol v3 / smpl encoder)
+```bash
+export GEMX_ROOT=/path/to/GEM-X
+# camera sanity check (no robot):
+python gear_sonic/examples/live_camera_teleop/webcam_stream.py --source 0 \
+    --kp-only --save webcam_test.mp4 --max-frames 60
+# live teleop:
+python gear_sonic/examples/live_camera_teleop/webcam_stream.py --source 0 \
+    --stream-sonic --window 30 --smooth 0.8
+```
+
+### Offline SMPL verify (no camera)
+```bash
+python gear_sonic/examples/live_camera_teleop/soma_pt_to_sonic_v3.py \
+    --gemx-root /path/to/GEM-X --pt /path/to/hpe_results.pt --fps 30 --loop
+```
+
+On the deploy side: press `]` to start, drop the robot (`9` in MuJoCo), then
+`ENTER` to enable ZMQ streaming. Use `O` for emergency stop. On real hardware,
+keep a safety operator on the E-stop.
+
+## Key options
+- `--window`: rolling-window length; smaller = higher fps.
+- `--no-imgfeat`: skip GEM-X's SAM-3D-Body image features for speed (lower
+  quality legs/depth).
+- `--smooth`: temporal smoothing of the streamed reference (0 = off,
+  0.6-0.85 steadier).
+- `--source`: camera index (`ls /dev/video*`) or a video file (stand-in).
+
+## Notes / limitations
+- The live path streams root-local SMPL pose + heading; it does not command an
+  explicit root translation, so controlled forward navigation is limited (best
+  combined with the kinematic planner for the lower body).
+- `smpl_pose` and wrist joints are streamed as zeros (the `smpl` encoder consumes
+  `smpl_joints` + anchor + wrists); wrist/finger fidelity is future work.
+- Monocular lower-body/foot estimation is the weakest signal; image features
+  (`--no-imgfeat` off) improve grounding at the cost of frame rate.

--- a/gear_sonic/examples/live_camera_teleop/README.md
+++ b/gear_sonic/examples/live_camera_teleop/README.md
@@ -32,6 +32,78 @@ mapping (no offline retargeter in the loop).
 3. Python deps in the environment you run these scripts in: `pyzmq`, `scipy`,
    `numpy`, `opencv-python`, and a CUDA-matched `onnxruntime-gpu`.
 
+## Camera setup
+
+Verify the camera before wiring up the robot. `webcam_stream.py` doubles as the
+test tool — `--kp-only` skips the 3D denoiser, so it starts fast and needs no
+checkpoint.
+
+### 1. Find the device
+
+```bash
+ls /dev/video*
+v4l2-ctl --list-devices                       # sudo apt install v4l-utils
+v4l2-ctl -d /dev/video0 --list-formats-ext    # modes the camera actually supports
+```
+
+The index in `/dev/videoN` is what you pass to `--source` (`/dev/video0` →
+`--source 0`). Many USB cameras expose several nodes for one physical device; the
+lowest-numbered one is usually the capture node.
+
+### 2. Preview the stream
+
+```bash
+export GEMX_ROOT=/path/to/GEM-X
+
+# with a display: live overlay window, press q to quit
+python gear_sonic/examples/live_camera_teleop/webcam_stream.py \
+    --source 0 --kp-only --show
+
+# headless (SSH/VNC): write an overlay clip instead
+python gear_sonic/examples/live_camera_teleop/webcam_stream.py \
+    --source 0 --kp-only --save webcam_test.mp4 --max-frames 60
+```
+
+You should see keypoints tracking your body and a steady frame rate in the status
+line. If keypoints are missing or jumping, fix that before streaming to the robot
+— the controller can only track what the estimator sees.
+
+### 3. Request a capture mode (optional)
+
+A camera's default mode is often low-resolution or low-fps, which caps the teleop
+rate. Request one of the modes reported by `--list-formats-ext`:
+
+```bash
+... --source 0 --resolution 1280x720 --cap-fps 30
+```
+
+Cameras silently ignore unsupported settings, so the script logs the mode it
+actually negotiated — check that line rather than assuming the request applied.
+
+### Framing
+
+Monocular estimation only knows what it can see:
+
+- keep the **full body in frame, including feet** — cropped legs make the lower
+  body unreliable, and that's what the controller balances on
+- stand roughly 2–3 m back, camera near torso height, lens roughly level
+- even front-facing light; avoid strong backlight
+- one person in frame (the largest detection is the one tracked)
+
+### Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `Could not open video source: 0` | Wrong index (`ls /dev/video*`), or user not in the `video` group (`sudo usermod -aG video $USER`, then re-login) |
+| Opens but frames fail or hang | Another process holds the device (browser tab, earlier run). Check with `sudo fuser /dev/video0` |
+| Very low fps | Camera negotiated a slow mode — set `--resolution` / `--cap-fps`, and try a smaller `--window` |
+| `--show` fails on a headless box | No display available; use `--save` instead |
+| No keypoints detected | Body not fully in frame, too dark, or too far away |
+
+> No camera handy? Pass a video file to `--source` (e.g. `--source clip.mp4`) to
+> exercise the full path, or use `soma_pt_to_sonic_v3.py` for a camera-free test
+> against the SONIC sim.
+
 ## Usage
 
 Run the SONIC deploy in ZMQ mode first (sim shown; use `real` for hardware):
@@ -46,10 +118,6 @@ bash deploy.sh --input-type zmq --zmq-host localhost --zmq-port 5556 --zmq-topic
 ### Live webcam (Protocol v3 / smpl encoder)
 ```bash
 export GEMX_ROOT=/path/to/GEM-X
-# camera sanity check (no robot):
-python gear_sonic/examples/live_camera_teleop/webcam_stream.py --source 0 \
-    --kp-only --save webcam_test.mp4 --max-frames 60
-# live teleop:
 python gear_sonic/examples/live_camera_teleop/webcam_stream.py --source 0 \
     --stream-sonic --window 30 --smooth 0.8
 ```
@@ -71,6 +139,8 @@ keep a safety operator on the E-stop.
 - `--smooth`: temporal smoothing of the streamed reference (0 = off,
   0.6-0.85 steadier).
 - `--source`: camera index (`ls /dev/video*`) or a video file (stand-in).
+- `--resolution` / `--cap-fps`: request a camera capture mode (see Camera setup).
+- `--kp-only` / `--show` / `--save`: 2D-only preview modes for camera checks.
 
 ## Notes / limitations
 - The live path streams root-local SMPL pose + heading; it does not command an

--- a/gear_sonic/examples/live_camera_teleop/soma_pt_to_sonic_v3.py
+++ b/gear_sonic/examples/live_camera_teleop/soma_pt_to_sonic_v3.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Offline driver: stream a saved GEM-X SOMA result to SONIC as SMPL (Protocol v3).
+
+Replays ``hpe_results.pt`` (the SOMA body params GEM-X already produced for a
+video) through the SOMA->SMPL converter and publishes the v3 stream SONIC's
+``smpl`` encoder expects. Useful to verify the SMPL path against the SONIC sim
+WITHOUT a camera.
+
+Requires GEM-X (https://github.com/NVlabs/GEM-X); pass --gemx-root or set GEMX_ROOT.
+
+Example:
+    python soma_pt_to_sonic_v3.py --gemx-root /path/to/GEM-X \
+        --pt /path/to/hpe_results.pt --fps 30 --loop
+"""
+
+import argparse
+import functools
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def _add_gemx_to_path() -> str | None:
+    root = os.environ.get("GEMX_ROOT")
+    for i, a in enumerate(sys.argv):
+        if a == "--gemx-root" and i + 1 < len(sys.argv):
+            root = sys.argv[i + 1]
+        elif a.startswith("--gemx-root="):
+            root = a.split("=", 1)[1]
+    if root and root not in sys.path:
+        sys.path.insert(0, root)
+    return root
+
+
+GEMX_ROOT = _add_gemx_to_path()
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # sibling modules
+torch.load = functools.partial(torch.load, weights_only=False)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--gemx-root", default=GEMX_ROOT, help="GEM-X repo root (or set $GEMX_ROOT)")
+    ap.add_argument("--pt", required=True, help="Path to hpe_results.pt")
+    ap.add_argument("--port", type=int, default=5556)
+    ap.add_argument("--fps", type=float, default=30.0)
+    ap.add_argument("--loop", action="store_true")
+    ap.add_argument("--max-frames", type=int, default=0)
+    ap.add_argument("--sonic-root", default=None, help="SONIC repo root (only if run outside the repo)")
+    ap.add_argument("--smooth", type=float, default=0.0, help="Temporal smoothing (0=off)")
+    ap.add_argument("--dry-run", action="store_true", help="Convert frame 0 and print, no ZMQ")
+    args = ap.parse_args()
+
+    if not args.gemx_root:
+        raise SystemExit("Provide --gemx-root <GEM-X repo root> or set GEMX_ROOT.")
+
+    try:
+        from gem.utils.soma_utils.soma_layer import SomaLayer
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "GEM-X not found (%s). Install https://github.com/NVlabs/GEM-X and pass "
+            "--gemx-root <path> or set GEMX_ROOT." % e
+        )
+    from soma_to_smpl import SomaToSmpl, SonicV3Publisher
+
+    pred = torch.load(args.pt)
+    g = pred["body_params_global"]
+    T = g["body_pose"].shape[0]
+    print(f"[soma->v3] loaded {T} frames from {args.pt}")
+
+    soma = SomaLayer(data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
+                     low_lod=True, device="cuda", identity_model_type="mhr", mode="warp")
+    conv = SomaToSmpl(soma, device="cuda", smooth=args.smooth, sonic_root=args.sonic_root)
+
+    def frame_at(t):
+        return {k: g[k][t] for k in ("body_pose", "global_orient", "identity_coeffs", "scale_params")}
+
+    if args.dry_run:
+        out = conv.convert(frame_at(0))
+        for k, v in out.items():
+            print(k, v.shape)
+        return
+
+    pub = SonicV3Publisher(port=args.port, sonic_root=args.sonic_root)
+    print(f"[soma->v3] publishing 'pose' v3 on tcp://*:{args.port}; enable streaming (ENTER) on deploy")
+    time.sleep(1.0)
+    dt = 1.0 / args.fps
+    sent = 0
+    try:
+        while True:
+            for t in range(T):
+                pub.publish(conv.convert(frame_at(t)))
+                sent += 1
+                if t % int(max(1, args.fps)) == 0:
+                    print(f"\r[soma->v3] frame {t + 1}/{T} (sent {sent})", end="")
+                time.sleep(dt)
+                if args.max_frames and sent >= args.max_frames:
+                    return
+            if not args.loop:
+                break
+            print("\n[soma->v3] loop restart")
+    except KeyboardInterrupt:
+        print("\n[soma->v3] stopped")
+    finally:
+        pub.close()
+        print("\n[soma->v3] done")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/examples/live_camera_teleop/soma_pt_to_sonic_v3.py
+++ b/gear_sonic/examples/live_camera_teleop/soma_pt_to_sonic_v3.py
@@ -15,13 +15,11 @@ Example:
 """
 
 import argparse
-import functools
 import os
+from pathlib import Path
 import sys
 import time
-from pathlib import Path
 
-import numpy as np
 import torch
 
 
@@ -39,7 +37,6 @@ def _add_gemx_to_path() -> str | None:
 
 GEMX_ROOT = _add_gemx_to_path()
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # sibling modules
-torch.load = functools.partial(torch.load, weights_only=False)
 
 
 def main():
@@ -50,7 +47,11 @@ def main():
     ap.add_argument("--fps", type=float, default=30.0)
     ap.add_argument("--loop", action="store_true")
     ap.add_argument("--max-frames", type=int, default=0)
-    ap.add_argument("--sonic-root", default=None, help="SONIC repo root (only if run outside the repo)")
+    ap.add_argument(
+        "--sonic-root",
+        default=os.environ.get("SONIC_ROOT"),
+        help="SONIC repo root, or set $SONIC_ROOT (only needed when run outside the repo)",
+    )
     ap.add_argument("--smooth", type=float, default=0.0, help="Temporal smoothing (0=off)")
     ap.add_argument("--dry-run", action="store_true", help="Convert frame 0 and print, no ZMQ")
     args = ap.parse_args()
@@ -67,13 +68,19 @@ def main():
         )
     from soma_to_smpl import SomaToSmpl, SonicV3Publisher
 
-    pred = torch.load(args.pt)
+    # hpe_results.pt holds non-tensor objects, so weights_only=False is required.
+    pred = torch.load(args.pt, weights_only=False)
     g = pred["body_params_global"]
     T = g["body_pose"].shape[0]
     print(f"[soma->v3] loaded {T} frames from {args.pt}")
 
-    soma = SomaLayer(data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
-                     low_lod=True, device="cuda", identity_model_type="mhr", mode="warp")
+    soma = SomaLayer(
+        data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
+        low_lod=True,
+        device="cuda",
+        identity_model_type="mhr",
+        mode="warp",
+    )
     conv = SomaToSmpl(soma, device="cuda", smooth=args.smooth, sonic_root=args.sonic_root)
 
     def frame_at(t):

--- a/gear_sonic/examples/live_camera_teleop/soma_to_smpl.py
+++ b/gear_sonic/examples/live_camera_teleop/soma_to_smpl.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SOMA -> SMPL conversion + SONIC Protocol-v3 publishing (live-webcam path).
+
+GEM-X estimates SOMA (77-joint) body params. SONIC's deployed policy has an
+``smpl`` encoder mode (Protocol v3) whose encoder observations are:
+  - smpl_joints (24x3, root-local)
+  - smpl_anchor_orientation (derived by the deploy from the streamed body_quat)
+  - motion_joint_positions_wrists (6 G1 wrist joints)
+
+This module converts a per-frame SOMA decode into the v3 stream fields, matching
+SONIC's own convention in
+``gear_sonic/scripts/pico_manager_thread_server.py:process_smpl_joints`` exactly:
+the root quaternion goes aa -> quat -> smpl_root_ytoz_up (+90 deg about X) ->
+remove_smpl_base_rot; smpl_joints are the SMPL joints with that root orientation
+removed (root-local), in Z-up. Optional temporal smoothing steadies the live
+signal.
+
+Note: this file imports ``gear_sonic`` (native when run from inside the SONIC
+repo). The SOMA body-model layer is passed in by the caller, so GEM-X is not
+imported here directly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import numpy as np
+import torch
+
+# Canonical SMPL 24 joint names (SMPL body kinematic tree order).
+SMPL_24_NAMES = [
+    "pelvis", "left_hip", "right_hip", "spine1", "left_knee", "right_knee",
+    "spine2", "left_ankle", "right_ankle", "spine3", "left_foot", "right_foot",
+    "neck", "left_collar", "right_collar", "head", "left_shoulder",
+    "right_shoulder", "left_elbow", "right_elbow", "left_wrist", "right_wrist",
+    "left_hand", "right_hand",
+]
+
+# Aliases mapping canonical SMPL joints -> SOMA rig joint names (Maya-style).
+# SOMA rig convention: "Foot" = ankle, "ToeBase" = foot/ball; "Arm" = shoulder,
+# "ForeArm" = elbow, "Hand" = wrist, "Shoulder" = collar/clavicle.
+_ALIASES = {
+    "pelvis": ["hips", "pelvis", "root"],
+    "left_hip": ["leftleg", "left_hip", "l_hip", "left_upleg"],
+    "right_hip": ["rightleg", "right_hip", "r_hip", "right_upleg"],
+    "spine1": ["spine1", "spine_1", "spine"],
+    "left_knee": ["leftshin", "left_knee", "l_knee"],
+    "right_knee": ["rightshin", "right_knee", "r_knee"],
+    "spine2": ["spine2", "spine_2"],
+    "left_ankle": ["leftfoot", "left_ankle", "l_ankle"],
+    "right_ankle": ["rightfoot", "right_ankle", "r_ankle"],
+    "spine3": ["chest", "spine3", "spine_3"],
+    "left_foot": ["lefttoebase", "left_foot", "l_foot", "left_toe"],
+    "right_foot": ["righttoebase", "right_foot", "r_foot", "right_toe"],
+    "neck": ["neck1", "neck"],
+    "left_collar": ["leftshoulder", "left_collar", "l_collar", "left_clavicle"],
+    "right_collar": ["rightshoulder", "right_collar", "r_collar", "right_clavicle"],
+    "head": ["head"],
+    "left_shoulder": ["leftarm", "left_shoulder", "l_shoulder", "left_upperarm"],
+    "right_shoulder": ["rightarm", "right_shoulder", "r_shoulder", "right_upperarm"],
+    "left_elbow": ["leftforearm", "left_elbow", "l_elbow", "left_lowerarm"],
+    "right_elbow": ["rightforearm", "right_elbow", "r_elbow"],
+    "left_wrist": ["lefthand", "left_wrist", "l_wrist"],
+    "right_wrist": ["righthand", "right_wrist", "r_wrist"],
+    "left_hand": ["lefthandmiddle1", "left_hand", "l_hand", "left_middle1"],
+    "right_hand": ["righthandmiddle1", "right_hand", "r_hand", "right_middle1"],
+}
+
+
+def _norm(name: str) -> str:
+    return name.lower().replace("-", "_").replace(" ", "_")
+
+
+def build_soma_to_smpl_index(soma_joint_names: list[str]) -> list[int]:
+    """Map each of the 24 SMPL joints to a SOMA joint index, by name alias."""
+    norm_names = [_norm(n) for n in soma_joint_names]
+    name_to_idx = {n: i for i, n in enumerate(norm_names)}
+    idx, unmatched = [], []
+    for smpl_name in SMPL_24_NAMES:
+        found = None
+        for alias in _ALIASES[smpl_name]:
+            if _norm(alias) in name_to_idx:
+                found = name_to_idx[_norm(alias)]
+                break
+        if found is None:
+            unmatched.append(smpl_name)
+            found = 0
+        idx.append(found)
+    if unmatched:
+        raise ValueError(
+            f"Could not map SMPL joints {unmatched} to SOMA joints. "
+            f"Available SOMA joint names: {soma_joint_names}"
+        )
+    return idx
+
+
+# Y-up -> Z-up rotation (+90 deg about X): same as smpl_root_ytoz_up on points.
+_YUP_TO_ZUP = torch.tensor(
+    [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=torch.float32
+)
+
+
+class SomaToSmpl:
+    """Convert per-frame SOMA decode -> SONIC v3 SMPL fields."""
+
+    def __init__(self, soma_layer, device="cuda", y_to_z_up=True, smooth=0.0, sonic_root=None):
+        self.soma = soma_layer
+        self.device = device
+        self.y_to_z_up = y_to_z_up
+        # Temporal smoothing weight on history (0 = off; 0.6-0.85 = progressively smoother).
+        self.smooth = float(smooth)
+        self._ema_joints = None
+        self._ema_quat = None
+
+        names = self._resolve_joint_names(soma_layer)
+        if len(names) == 78 and _norm(names[0]) == "root":
+            names = names[1:]  # align to the 77-joint forward() output
+        self.soma_joint_names = names
+        self.smpl_idx = build_soma_to_smpl_index(names)
+        self._R_up = _YUP_TO_ZUP.to(device)
+
+        # SONIC's EXACT SMPL convention helpers (native import inside the repo).
+        import sys
+        if sonic_root and sonic_root not in sys.path:
+            sys.path.insert(0, sonic_root)
+        from gear_sonic.trl.utils.torch_transform import (
+            angle_axis_to_quaternion, quat_apply, quat_inv,
+        )
+        from gear_sonic.isaac_utils.rotations import (
+            remove_smpl_base_rot, smpl_root_ytoz_up,
+        )
+        self._aa2quat = angle_axis_to_quaternion
+        self._quat_apply = quat_apply
+        self._quat_inv = quat_inv
+        self._remove_base_rot = remove_smpl_base_rot
+        self._ytoz = smpl_root_ytoz_up
+
+    @staticmethod
+    def _resolve_joint_names(soma_layer):
+        inner = getattr(soma_layer, "soma", soma_layer)
+        rig = getattr(inner, "rig_data", None)
+        if rig is not None and hasattr(rig, "files") and "joint_names" in rig.files:
+            return [str(x) for x in rig["joint_names"]]
+        if isinstance(rig, dict) and "joint_names" in rig:
+            return [str(x) for x in rig["joint_names"]]
+        names = getattr(inner, "joint_names", None) or getattr(soma_layer, "joint_names", None)
+        if names is not None:
+            return [str(x) for x in names]
+        raise AttributeError(
+            "Could not find SOMA joint_names (checked .soma.rig_data['joint_names'])."
+        )
+
+    @torch.no_grad()
+    def convert(self, soma_params: dict) -> dict:
+        """soma_params: per-frame tensors (body_pose, global_orient,
+        identity_coeffs, scale_params[, transl]). Returns v3 stream fields."""
+        def _t(x):
+            x = torch.as_tensor(x, dtype=torch.float32, device=self.device)
+            return x.unsqueeze(0) if x.dim() == 1 else x
+
+        body_pose = _t(soma_params["body_pose"])
+        global_orient = _t(soma_params["global_orient"])
+        identity = _t(soma_params["identity_coeffs"])
+        scale = _t(soma_params["scale_params"])
+        transl = _t(soma_params.get("transl", torch.zeros(3, device=self.device)))
+
+        out = self.soma(
+            body_pose=body_pose, global_orient=global_orient, transl=transl,
+            identity_coeffs=identity, scale_params=scale,
+        )
+        joints77 = out["joints"][0]                       # (77,3) GEM y-up, global applied
+        joints24 = joints77[self.smpl_idx]                # (24,3)
+
+        # Mirror SONIC's process_smpl_joints convention exactly.
+        g_quat = self._aa2quat(global_orient)             # (1,4) wxyz, y-up
+        g_quat_z = self._ytoz(g_quat)                     # (1,4) z-up
+        g_quat_nobase = self._remove_base_rot(g_quat_z, w_last=False)  # (1,4)
+
+        joints0 = joints24 - joints24[0:1]                # root at origin (y-up)
+        joints_z = joints0 @ self._R_up.T                 # (24,3) z-up
+        inv = self._quat_inv(g_quat_nobase).repeat(joints_z.shape[0], 1)  # (24,4)
+        smpl_joints_local = self._quat_apply(inv, joints_z)               # (24,3)
+
+        smpl_joints = smpl_joints_local.unsqueeze(0).cpu().numpy().astype(np.float32)
+        body_quat = g_quat_nobase.reshape(1, 4).cpu().numpy().astype(np.float32)
+
+        # Temporal smoothing (reduces live jitter -> stepping/wobble).
+        if self.smooth > 0.0:
+            w = self.smooth
+            if self._ema_joints is None:
+                self._ema_joints = smpl_joints.copy()
+                self._ema_quat = body_quat.copy()
+            else:
+                self._ema_joints = w * self._ema_joints + (1.0 - w) * smpl_joints
+                q_prev, q_new = self._ema_quat, body_quat.copy()
+                if float((q_prev * q_new).sum()) < 0.0:   # sign-align before lerp
+                    q_new = -q_new
+                q = w * q_prev + (1.0 - w) * q_new
+                self._ema_quat = q / (np.linalg.norm(q) + 1e-8)
+            smpl_joints = self._ema_joints.astype(np.float32)
+            body_quat = self._ema_quat.astype(np.float32)
+
+        smpl_pose = np.zeros((1, 21, 3), dtype=np.float32)
+        wrists = np.zeros((1, 6), dtype=np.float32)
+        return {
+            "smpl_joints": smpl_joints,
+            "body_quat": body_quat,
+            "smpl_pose": smpl_pose,
+            "wrists": wrists,
+        }
+
+
+HEADER_SIZE = 1280  # SONIC ZMQ header size (see gear_sonic zmq_planner_sender.py)
+
+
+def _fallback_pack_pose_message(pose_data: dict, topic: str = "pose", version: int = 3) -> bytes:
+    """Byte-identical fallback for SONIC's pack_pose_message.
+
+    Layout: [topic_bytes][1280-byte JSON header][concatenated little-endian binary fields].
+    """
+    dtype_map = {
+        np.dtype(np.float32): "f32", np.dtype(np.float64): "f64",
+        np.dtype(np.int32): "i32", np.dtype(np.int64): "i64", np.dtype(bool): "bool",
+    }
+    fields, binary = [], []
+    for key, value in pose_data.items():
+        if not isinstance(value, np.ndarray):
+            continue
+        dtype_str = dtype_map.get(value.dtype, "f32")
+        if dtype_str == "f32" and value.dtype != np.float32:
+            value = value.astype(np.float32)
+        if not value.flags["C_CONTIGUOUS"]:
+            value = np.ascontiguousarray(value)
+        fields.append({"name": key, "dtype": dtype_str, "shape": list(value.shape)})
+        binary.append(value.tobytes())
+    header = {"v": version, "endian": "le", "count": 1, "fields": fields}
+    header_json = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    if len(header_json) > HEADER_SIZE:
+        raise ValueError(f"Header too large: {len(header_json)} > {HEADER_SIZE}")
+    return topic.encode("utf-8") + header_json.ljust(HEADER_SIZE, b"\x00") + b"".join(binary)
+
+
+def _get_packer(sonic_root: str | None = None):
+    """Return SONIC's pack_pose_message if importable, else the local fallback.
+
+    Native import works when run from inside the SONIC repo; pass ``sonic_root``
+    only if running from outside.
+    """
+    if sonic_root and sonic_root not in sys.path:
+        sys.path.insert(0, sonic_root)
+    try:
+        from gear_sonic.utils.teleop.zmq.zmq_planner_sender import pack_pose_message
+        print("[bridge] Using SONIC's pack_pose_message (exact wire format).")
+        return pack_pose_message
+    except Exception as exc:
+        print(f"[bridge] gear_sonic not importable ({exc}); using built-in fallback packer.")
+        return _fallback_pack_pose_message
+
+
+class SonicV3Publisher:
+    """ZMQ PUB publisher for SONIC Protocol v3 (SMPL) using SONIC's exact packer."""
+
+    def __init__(self, port=5556, topic="pose", sonic_root=None):
+        import zmq
+
+        self.pack = _get_packer(sonic_root)
+        self.topic = topic
+        self.frame_index = 0
+        self.ctx = zmq.Context()
+        self.sock = self.ctx.socket(zmq.PUB)
+        self.sock.bind(f"tcp://*:{port}")
+
+    def publish(self, fields: dict):
+        joint_pos = np.zeros((1, 29), dtype=np.float32)
+        joint_pos[:, 23:29] = fields["wrists"]            # only wrists meaningful in v3
+        pose_data = {
+            "smpl_joints": fields["smpl_joints"].reshape(1, 24, 3),
+            "smpl_pose": fields["smpl_pose"].reshape(1, 21, 3),
+            "joint_pos": joint_pos,
+            "joint_vel": np.zeros((1, 29), dtype=np.float32),
+            "body_quat": fields["body_quat"].reshape(1, 4),  # wxyz, SONIC convention
+            "frame_index": np.array([self.frame_index], dtype=np.int64),
+        }
+        self.sock.send(self.pack(pose_data, topic=self.topic, version=3))
+        self.frame_index += 1
+
+    def close(self):
+        self.sock.close(0)
+        self.ctx.term()

--- a/gear_sonic/examples/live_camera_teleop/soma_to_smpl.py
+++ b/gear_sonic/examples/live_camera_teleop/soma_to_smpl.py
@@ -31,11 +31,30 @@ import torch
 
 # Canonical SMPL 24 joint names (SMPL body kinematic tree order).
 SMPL_24_NAMES = [
-    "pelvis", "left_hip", "right_hip", "spine1", "left_knee", "right_knee",
-    "spine2", "left_ankle", "right_ankle", "spine3", "left_foot", "right_foot",
-    "neck", "left_collar", "right_collar", "head", "left_shoulder",
-    "right_shoulder", "left_elbow", "right_elbow", "left_wrist", "right_wrist",
-    "left_hand", "right_hand",
+    "pelvis",
+    "left_hip",
+    "right_hip",
+    "spine1",
+    "left_knee",
+    "right_knee",
+    "spine2",
+    "left_ankle",
+    "right_ankle",
+    "spine3",
+    "left_foot",
+    "right_foot",
+    "neck",
+    "left_collar",
+    "right_collar",
+    "head",
+    "left_shoulder",
+    "right_shoulder",
+    "left_elbow",
+    "right_elbow",
+    "left_wrist",
+    "right_wrist",
+    "left_hand",
+    "right_hand",
 ]
 
 # Aliases mapping canonical SMPL joints -> SOMA rig joint names (Maya-style).
@@ -97,9 +116,7 @@ def build_soma_to_smpl_index(soma_joint_names: list[str]) -> list[int]:
 
 
 # Y-up -> Z-up rotation (+90 deg about X): same as smpl_root_ytoz_up on points.
-_YUP_TO_ZUP = torch.tensor(
-    [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=torch.float32
-)
+_YUP_TO_ZUP = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=torch.float32)
 
 
 class SomaToSmpl:
@@ -121,16 +138,19 @@ class SomaToSmpl:
         self.smpl_idx = build_soma_to_smpl_index(names)
         self._R_up = _YUP_TO_ZUP.to(device)
 
-        # SONIC's EXACT SMPL convention helpers (native import inside the repo).
-        import sys
+        # Deferred: sonic_root must be on sys.path before gear_sonic resolves.
         if sonic_root and sonic_root not in sys.path:
             sys.path.insert(0, sonic_root)
-        from gear_sonic.trl.utils.torch_transform import (
-            angle_axis_to_quaternion, quat_apply, quat_inv,
-        )
         from gear_sonic.isaac_utils.rotations import (
-            remove_smpl_base_rot, smpl_root_ytoz_up,
+            remove_smpl_base_rot,
+            smpl_root_ytoz_up,
         )
+        from gear_sonic.trl.utils.torch_transform import (
+            angle_axis_to_quaternion,
+            quat_apply,
+            quat_inv,
+        )
+
         self._aa2quat = angle_axis_to_quaternion
         self._quat_apply = quat_apply
         self._quat_inv = quat_inv
@@ -141,6 +161,7 @@ class SomaToSmpl:
     def _resolve_joint_names(soma_layer):
         inner = getattr(soma_layer, "soma", soma_layer)
         rig = getattr(inner, "rig_data", None)
+        # rig_data is an NpzFile: .files lists key names, arrays come off the object.
         if rig is not None and hasattr(rig, "files") and "joint_names" in rig.files:
             return [str(x) for x in rig["joint_names"]]
         if isinstance(rig, dict) and "joint_names" in rig:
@@ -148,14 +169,23 @@ class SomaToSmpl:
         names = getattr(inner, "joint_names", None) or getattr(soma_layer, "joint_names", None)
         if names is not None:
             return [str(x) for x in names]
-        raise AttributeError(
-            "Could not find SOMA joint_names (checked .soma.rig_data['joint_names'])."
-        )
+        raise AttributeError("Could not find SOMA joint_names (checked .soma.rig_data['joint_names']).")
 
     @torch.no_grad()
     def convert(self, soma_params: dict) -> dict:
         """soma_params: per-frame tensors (body_pose, global_orient,
         identity_coeffs, scale_params[, transl]). Returns v3 stream fields."""
+        missing = [
+            k for k in ("body_pose", "global_orient", "identity_coeffs", "scale_params") if k not in soma_params
+        ]
+        if missing:
+            raise KeyError(
+                f"SomaToSmpl.convert() requires {missing}; these come from GEM-X's "
+                "EnDecoder.decode() (soma_v2). There is no safe zero default here: "
+                "scale_params[0] is a global scale factor, so zeros would collapse the "
+                "rest shape and stream an all-zeros skeleton to the controller."
+            )
+
         def _t(x):
             x = torch.as_tensor(x, dtype=torch.float32, device=self.device)
             return x.unsqueeze(0) if x.dim() == 1 else x
@@ -167,21 +197,24 @@ class SomaToSmpl:
         transl = _t(soma_params.get("transl", torch.zeros(3, device=self.device)))
 
         out = self.soma(
-            body_pose=body_pose, global_orient=global_orient, transl=transl,
-            identity_coeffs=identity, scale_params=scale,
+            body_pose=body_pose,
+            global_orient=global_orient,
+            transl=transl,
+            identity_coeffs=identity,
+            scale_params=scale,
         )
-        joints77 = out["joints"][0]                       # (77,3) GEM y-up, global applied
-        joints24 = joints77[self.smpl_idx]                # (24,3)
+        joints77 = out["joints"][0]  # (77,3) GEM y-up, global applied
+        joints24 = joints77[self.smpl_idx]  # (24,3)
 
         # Mirror SONIC's process_smpl_joints convention exactly.
-        g_quat = self._aa2quat(global_orient)             # (1,4) wxyz, y-up
-        g_quat_z = self._ytoz(g_quat)                     # (1,4) z-up
+        g_quat = self._aa2quat(global_orient)  # (1,4) wxyz, y-up
+        g_quat_z = self._ytoz(g_quat)  # (1,4) z-up
         g_quat_nobase = self._remove_base_rot(g_quat_z, w_last=False)  # (1,4)
 
-        joints0 = joints24 - joints24[0:1]                # root at origin (y-up)
-        joints_z = joints0 @ self._R_up.T                 # (24,3) z-up
+        joints0 = joints24 - joints24[0:1]  # root at origin (y-up)
+        joints_z = joints0 @ self._R_up.T  # (24,3) z-up
         inv = self._quat_inv(g_quat_nobase).repeat(joints_z.shape[0], 1)  # (24,4)
-        smpl_joints_local = self._quat_apply(inv, joints_z)               # (24,3)
+        smpl_joints_local = self._quat_apply(inv, joints_z)  # (24,3)
 
         smpl_joints = smpl_joints_local.unsqueeze(0).cpu().numpy().astype(np.float32)
         body_quat = g_quat_nobase.reshape(1, 4).cpu().numpy().astype(np.float32)
@@ -195,7 +228,7 @@ class SomaToSmpl:
             else:
                 self._ema_joints = w * self._ema_joints + (1.0 - w) * smpl_joints
                 q_prev, q_new = self._ema_quat, body_quat.copy()
-                if float((q_prev * q_new).sum()) < 0.0:   # sign-align before lerp
+                if float((q_prev * q_new).sum()) < 0.0:  # sign-align before lerp
                     q_new = -q_new
                 q = w * q_prev + (1.0 - w) * q_new
                 self._ema_quat = q / (np.linalg.norm(q) + 1e-8)
@@ -221,8 +254,11 @@ def _fallback_pack_pose_message(pose_data: dict, topic: str = "pose", version: i
     Layout: [topic_bytes][1280-byte JSON header][concatenated little-endian binary fields].
     """
     dtype_map = {
-        np.dtype(np.float32): "f32", np.dtype(np.float64): "f64",
-        np.dtype(np.int32): "i32", np.dtype(np.int64): "i64", np.dtype(bool): "bool",
+        np.dtype(np.float32): "f32",
+        np.dtype(np.float64): "f64",
+        np.dtype(np.int32): "i32",
+        np.dtype(np.int64): "i64",
+        np.dtype(bool): "bool",
     }
     fields, binary = [], []
     for key, value in pose_data.items():
@@ -252,6 +288,7 @@ def _get_packer(sonic_root: str | None = None):
         sys.path.insert(0, sonic_root)
     try:
         from gear_sonic.utils.teleop.zmq.zmq_planner_sender import pack_pose_message
+
         print("[bridge] Using SONIC's pack_pose_message (exact wire format).")
         return pack_pose_message
     except Exception as exc:
@@ -274,7 +311,7 @@ class SonicV3Publisher:
 
     def publish(self, fields: dict):
         joint_pos = np.zeros((1, 29), dtype=np.float32)
-        joint_pos[:, 23:29] = fields["wrists"]            # only wrists meaningful in v3
+        joint_pos[:, 23:29] = fields["wrists"]  # only wrists meaningful in v3
         pose_data = {
             "smpl_joints": fields["smpl_joints"].reshape(1, 24, 3),
             "smpl_pose": fields["smpl_pose"].reshape(1, 21, 3),

--- a/gear_sonic/examples/live_camera_teleop/webcam_stream.py
+++ b/gear_sonic/examples/live_camera_teleop/webcam_stream.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Real-time GEM-X pose estimation from a live webcam -> SONIC (live-webcam path).
+
+Captures frames from a webcam (or a video file used as a stand-in), runs the
+GEM-X ONNX pipeline (YOLOX detect -> VitPose 2D -> GEM denoiser) over a rolling
+sliding window, decodes per-frame SOMA body params, and (with --stream-sonic)
+converts each frame SOMA->SMPL and publishes Protocol v3 to SONIC's smpl encoder.
+
+Requires GEM-X (https://github.com/NVlabs/GEM-X) installed separately. Point to
+its repo root with --gemx-root or the GEMX_ROOT environment variable.
+
+Examples:
+    # camera-only sanity check (no robot), saves an overlay video
+    python webcam_stream.py --gemx-root /path/to/GEM-X --source 0 \
+        --kp-only --save webcam_test.mp4 --max-frames 60
+
+    # live teleop -> SONIC
+    python webcam_stream.py --gemx-root /path/to/GEM-X --source 0 \
+        --stream-sonic --window 30 --smooth 0.8
+"""
+
+# ruff: noqa: E402
+import argparse
+import os
+import sys
+import time
+from collections import deque
+from pathlib import Path
+
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+os.environ.setdefault("EGL_PLATFORM", "surfaceless")
+
+
+def _add_gemx_to_path() -> str | None:
+    """Resolve the GEM-X repo root (from --gemx-root or $GEMX_ROOT) and add it to
+    sys.path so ``gem`` and GEM-X's ``scripts.demo`` modules import."""
+    root = os.environ.get("GEMX_ROOT")
+    argv = sys.argv
+    for i, a in enumerate(argv):
+        if a == "--gemx-root" and i + 1 < len(argv):
+            root = argv[i + 1]
+        elif a.startswith("--gemx-root="):
+            root = a.split("=", 1)[1]
+    if root and root not in sys.path:
+        sys.path.insert(0, root)
+    return root
+
+
+GEMX_ROOT = _add_gemx_to_path()
+
+import cv2
+import numpy as np
+import torch
+
+try:
+    from scripts.demo.demo_soma_onnx import (
+        load_denoiser, load_vitpose, run_denoiser_onnx, run_vitpose_onnx,
+    )
+    from gem.utils.cam_utils import estimate_K
+    from gem.utils.geo_transform import compute_cam_angvel, get_bbx_xys_from_xyxy
+    from gem.utils.pylogger import Log
+except ModuleNotFoundError as e:
+    raise SystemExit(
+        "GEM-X not found (%s). Install https://github.com/NVlabs/GEM-X and pass "
+        "--gemx-root <path> or set GEMX_ROOT to its repo root." % e
+    )
+
+# sibling module (same folder)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _open_source(source: str):
+    cap = cv2.VideoCapture(int(source)) if source.isdigit() else cv2.VideoCapture(source)
+    if not cap.isOpened():
+        raise RuntimeError(f"Could not open video source: {source}")
+    return cap
+
+
+class GemWebcamStreamer:
+    """Rolling-window GEM-X inference over a live frame source."""
+
+    def __init__(self, gemx_root, window=120, no_imgfeat=True, device="cuda"):
+        self.gemx_root = gemx_root
+        self.window = window
+        self.no_imgfeat = no_imgfeat
+        self.device = device
+
+        from gem.utils.yolox_detector import YOLOXDetector
+        self.yolox = YOLOXDetector(device=device)
+
+        self.vitpose_runner, self.vitpose_backend = load_vitpose()
+        self.denoiser_runner, self.denoiser_backend = load_denoiser(no_imgfeat=no_imgfeat)
+        Log.info(f"[webcam] backends: vitpose={self.vitpose_backend}, denoiser={self.denoiser_backend}")
+
+        self._endecoder = None
+        self._get_body_params_w_Rt_v2 = None
+        self.buf_kp2d = deque(maxlen=window)
+        self.buf_bbx = deque(maxlen=window)
+        self.K = None
+
+    def _ensure_decoder(self, ckpt_path=None):
+        if self._endecoder is not None:
+            return
+        import hydra
+        from hydra import compose, initialize_config_dir
+        from gem.pipeline.gem_pipeline import get_body_params_w_Rt_v2
+
+        cfg_dir = str(Path(self.gemx_root) / "configs")
+        with initialize_config_dir(version_base="1.3", config_dir=cfg_dir):
+            cfg = compose(config_name="demo_soma", overrides=[
+                "exp=gem_soma_regression", "video_name=stream", "video_path=stream",
+                "use_wandb=false", "task=test",
+            ])
+        model = hydra.utils.instantiate(cfg.model, _recursive_=False)
+        if ckpt_path is None:
+            from gem.utils.hf_utils import download_checkpoint
+            ckpt_path = download_checkpoint()
+        model.load_pretrained_model(ckpt_path)
+        model = model.eval().to(self.device)
+        self._endecoder = model.endecoder
+        if self._endecoder.obs_indices_dict is None:
+            self._endecoder.build_obs_indices_dict()
+        self._get_body_params_w_Rt_v2 = get_body_params_w_Rt_v2
+
+    def detect_bbox(self, frame_bgr, W, H):
+        from gem.utils.yolox_detector import detect_and_track
+        bbx_xyxy_np, _ = detect_and_track(frame_bgr[None], self.yolox)
+        bbx_xyxy = torch.from_numpy(bbx_xyxy_np).float()
+        bbx_xyxy[:, [0, 2]] = bbx_xyxy[:, [0, 2]].clamp(0, W - 1)
+        bbx_xyxy[:, [1, 3]] = bbx_xyxy[:, [1, 3]].clamp(0, H - 1)
+        return get_bbx_xys_from_xyxy(bbx_xyxy, base_enlarge=1.2).float()[0]
+
+    @torch.no_grad()
+    def process_frame(self, frame_rgb, W, H, decode=True):
+        """Ingest one frame; return (kp2d [77,3], soma_params or None)."""
+        if self.K is None:
+            self.K = estimate_K(W, H)
+
+        bbx_xys = self.detect_bbox(frame_rgb, W, H)
+        vitpose = run_vitpose_onnx(self.vitpose_runner, self.vitpose_backend,
+                                   frame_rgb[None], bbx_xys[None])
+        kp2d = vitpose[0] if isinstance(vitpose, tuple) else vitpose
+        kp2d = torch.as_tensor(kp2d)[0]                   # [77,3]
+
+        self.buf_kp2d.append(kp2d)
+        self.buf_bbx.append(bbx_xys)
+        if not decode or len(self.buf_kp2d) < 2:
+            return kp2d, None
+
+        L = len(self.buf_kp2d)
+        obs = torch.stack(list(self.buf_kp2d)).unsqueeze(0)
+        bbx = torch.stack(list(self.buf_bbx)).unsqueeze(0)
+        K = self.K.repeat(L, 1, 1).unsqueeze(0)
+        f_imgseq = torch.zeros(1, L, 1024)                # no-imgfeat
+        cam_angvel = compute_cam_angvel(torch.eye(3).repeat(L, 1, 1)).unsqueeze(0)  # static cam
+
+        batch = {"obs": obs, "bbx_xys": bbx, "K_fullimg": K,
+                 "f_imgseq": f_imgseq, "f_cam_angvel": cam_angvel}
+        pred_x, _pred_cam = run_denoiser_onnx(self.denoiser_runner, self.denoiser_backend, batch)
+
+        self._ensure_decoder()
+        decode_dict = self._endecoder.decode(pred_x)
+
+        # WORLD (gravity-aligned) root orientation, like the offline pipeline.
+        # decode_dict["global_orient"] is camera-frame; fuse to gravity-view so the
+        # robot doesn't pitch/tip to a tilted camera "up".
+        world_global_orient = decode_dict["global_orient"][0, -1].cpu()  # fallback
+        if "global_orient_gv" in decode_dict and "local_transl_vel" in decode_dict:
+            gp = self._get_body_params_w_Rt_v2(
+                global_orient_gv=decode_dict["global_orient_gv"],
+                local_transl_vel=decode_dict["local_transl_vel"],
+                global_orient_c=decode_dict["global_orient"],
+                cam_angvel=cam_angvel.to(pred_x.device),
+            )
+            world_global_orient = gp["global_orient"][0, -1].cpu()
+
+        soma = {"body_pose": decode_dict["body_pose"][0, -1].cpu(),
+                "global_orient": world_global_orient}
+        for k in ("identity_coeffs", "scale_params"):
+            if k in decode_dict:
+                soma[k] = decode_dict[k][0, -1].cpu()
+        return kp2d, soma
+
+
+def _draw_overlay(frame_bgr, kp2d, conf_thr=0.4):
+    for x, y, c in kp2d.numpy():
+        if c > conf_thr:
+            cv2.circle(frame_bgr, (int(x), int(y)), 2, (0, 255, 0), -1)
+    return frame_bgr
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--gemx-root", default=GEMX_ROOT, help="GEM-X repo root (or set $GEMX_ROOT)")
+    ap.add_argument("--source", default="0", help="Webcam index (e.g. 0) or video file path")
+    ap.add_argument("--window", type=int, default=120, help="Rolling window length")
+    ap.add_argument("--no-imgfeat", action="store_true", help="Skip SAM3DB image features (faster)")
+    ap.add_argument("--kp-only", action="store_true", help="2D keypoints only (skip denoiser/decode)")
+    ap.add_argument("--max-frames", type=int, default=0, help="Stop after N frames (0 = run forever)")
+    ap.add_argument("--show", action="store_true", help="Show cv2 preview window (needs a display)")
+    ap.add_argument("--save", default=None, help="Optional path to save 2D-overlay preview mp4")
+    ap.add_argument("--stream-sonic", action="store_true", help="Publish SMPL v3 stream to SONIC")
+    ap.add_argument("--port", type=int, default=5556, help="ZMQ PUB port for SONIC stream")
+    ap.add_argument("--sonic-root", default=None, help="SONIC repo root (only if run outside the repo)")
+    ap.add_argument("--smooth", type=float, default=0.75,
+                    help="Temporal smoothing of streamed SMPL (0=off, 0.6-0.85 smoother)")
+    args = ap.parse_args()
+
+    if not args.gemx_root:
+        raise SystemExit("Provide --gemx-root <GEM-X repo root> or set GEMX_ROOT.")
+
+    cap = _open_source(args.source)
+    W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 640
+    H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 480
+    src_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    Log.info(f"[webcam] source={args.source} {W}x{H} @ ~{src_fps:.1f}fps")
+
+    streamer = GemWebcamStreamer(args.gemx_root, window=args.window,
+                                 no_imgfeat=args.no_imgfeat or True)
+
+    converter, publisher = None, None
+    if args.stream_sonic:
+        from soma_to_smpl import SomaToSmpl, SonicV3Publisher
+        from gem.utils.soma_utils.soma_layer import SomaLayer
+        soma_layer = SomaLayer(data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
+                               low_lod=True, device="cuda",
+                               identity_model_type="mhr", mode="warp")
+        converter = SomaToSmpl(soma_layer, device="cuda", smooth=args.smooth, sonic_root=args.sonic_root)
+        publisher = SonicV3Publisher(port=args.port, sonic_root=args.sonic_root)
+        Log.info(f"[webcam] streaming SMPL v3 to SONIC on tcp://*:{args.port}")
+
+    writer = None
+    if args.save:
+        Path(args.save).parent.mkdir(parents=True, exist_ok=True)
+        writer = cv2.VideoWriter(args.save, cv2.VideoWriter_fourcc(*"mp4v"), src_fps, (W, H))
+
+    n, t_start, t_last = 0, time.time(), time.time()
+    try:
+        while True:
+            ok, frame_bgr = cap.read()
+            if not ok:
+                break
+            frame_rgb = frame_bgr[..., ::-1].copy()
+            kp2d, soma = streamer.process_frame(frame_rgb, W, H, decode=not args.kp_only)
+
+            if publisher is not None and soma is not None:
+                publisher.publish(converter.convert(soma))
+
+            n += 1
+            now = time.time()
+            inst_fps = 1.0 / max(1e-6, now - t_last)
+            t_last = now
+            print(f"\r[webcam] frame {n} | {inst_fps:5.1f} fps | "
+                  f"soma={'yes' if soma else 'warmup/kp-only'}", end="", flush=True)
+
+            if writer is not None or args.show:
+                vis = _draw_overlay(frame_bgr, kp2d)
+                if writer is not None:
+                    writer.write(vis)
+                if args.show:
+                    cv2.imshow("GEM webcam", vis)
+                    if cv2.waitKey(1) & 0xFF == ord("q"):
+                        break
+            if args.max_frames and n >= args.max_frames:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cap.release()
+        if publisher is not None:
+            publisher.close()
+        if writer is not None:
+            writer.release()
+        if args.show:
+            cv2.destroyAllWindows()
+        dur = time.time() - t_start
+        print(f"\n[webcam] processed {n} frames in {dur:.1f}s ({n / max(1e-6, dur):.1f} fps avg)")
+
+
+if __name__ == "__main__":
+    main()

--- a/gear_sonic/examples/live_camera_teleop/webcam_stream.py
+++ b/gear_sonic/examples/live_camera_teleop/webcam_stream.py
@@ -11,7 +11,10 @@ Requires GEM-X (https://github.com/NVlabs/GEM-X) installed separately. Point to
 its repo root with --gemx-root or the GEMX_ROOT environment variable.
 
 Examples:
-    # camera-only sanity check (no robot), saves an overlay video
+    # camera-only sanity check (no robot): live overlay window
+    python webcam_stream.py --gemx-root /path/to/GEM-X --source 0 --kp-only --show
+
+    # same, headless: write an overlay clip instead
     python webcam_stream.py --gemx-root /path/to/GEM-X --source 0 \
         --kp-only --save webcam_test.mp4 --max-frames 60
 
@@ -22,11 +25,11 @@ Examples:
 
 # ruff: noqa: E402
 import argparse
+from collections import deque
 import os
+from pathlib import Path
 import sys
 import time
-from collections import deque
-from pathlib import Path
 
 os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
 os.environ.setdefault("EGL_PLATFORM", "surfaceless")
@@ -50,16 +53,18 @@ def _add_gemx_to_path() -> str | None:
 GEMX_ROOT = _add_gemx_to_path()
 
 import cv2
-import numpy as np
 import torch
 
 try:
-    from scripts.demo.demo_soma_onnx import (
-        load_denoiser, load_vitpose, run_denoiser_onnx, run_vitpose_onnx,
-    )
     from gem.utils.cam_utils import estimate_K
     from gem.utils.geo_transform import compute_cam_angvel, get_bbx_xys_from_xyxy
     from gem.utils.pylogger import Log
+    from scripts.demo.demo_soma_onnx import (
+        load_denoiser,
+        load_vitpose,
+        run_denoiser_onnx,
+        run_vitpose_onnx,
+    )
 except ModuleNotFoundError as e:
     raise SystemExit(
         "GEM-X not found (%s). Install https://github.com/NVlabs/GEM-X and pass "
@@ -70,10 +75,32 @@ except ModuleNotFoundError as e:
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 
-def _open_source(source: str):
-    cap = cv2.VideoCapture(int(source)) if source.isdigit() else cv2.VideoCapture(source)
+def _open_source(source: str, resolution=None, cap_fps=None, fourcc="MJPG"):
+    """Open a webcam index or video file, optionally requesting a capture mode.
+
+    Cameras silently ignore unsupported settings, so the negotiated mode must be
+    read back rather than assumed.
+    """
+    is_camera = source.isdigit()
+    cap = cv2.VideoCapture(int(source)) if is_camera else cv2.VideoCapture(source)
     if not cap.isOpened():
-        raise RuntimeError(f"Could not open video source: {source}")
+        raise RuntimeError(
+            f"Could not open video source: {source}. For a camera, check the index "
+            "(ls /dev/video*), that no other process holds the device, and that you "
+            "are in the 'video' group."
+        )
+    if is_camera:
+        if fourcc:
+            cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*fourcc))
+        if resolution:
+            try:
+                w, h = (int(v) for v in resolution.lower().split("x"))
+            except ValueError:
+                raise SystemExit(f"--resolution must look like 1280x720, got {resolution!r}")
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH, w)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, h)
+        if cap_fps:
+            cap.set(cv2.CAP_PROP_FPS, cap_fps)
     return cap
 
 
@@ -87,6 +114,7 @@ class GemWebcamStreamer:
         self.device = device
 
         from gem.utils.yolox_detector import YOLOXDetector
+
         self.yolox = YOLOXDetector(device=device)
 
         self.vitpose_runner, self.vitpose_backend = load_vitpose()
@@ -102,19 +130,26 @@ class GemWebcamStreamer:
     def _ensure_decoder(self, ckpt_path=None):
         if self._endecoder is not None:
             return
+        from gem.pipeline.gem_pipeline import get_body_params_w_Rt_v2
         import hydra
         from hydra import compose, initialize_config_dir
-        from gem.pipeline.gem_pipeline import get_body_params_w_Rt_v2
 
         cfg_dir = str(Path(self.gemx_root) / "configs")
         with initialize_config_dir(version_base="1.3", config_dir=cfg_dir):
-            cfg = compose(config_name="demo_soma", overrides=[
-                "exp=gem_soma_regression", "video_name=stream", "video_path=stream",
-                "use_wandb=false", "task=test",
-            ])
+            cfg = compose(
+                config_name="demo_soma",
+                overrides=[
+                    "exp=gem_soma_regression",
+                    "video_name=stream",
+                    "video_path=stream",
+                    "use_wandb=false",
+                    "task=test",
+                ],
+            )
         model = hydra.utils.instantiate(cfg.model, _recursive_=False)
         if ckpt_path is None:
             from gem.utils.hf_utils import download_checkpoint
+
             ckpt_path = download_checkpoint()
         model.load_pretrained_model(ckpt_path)
         model = model.eval().to(self.device)
@@ -125,6 +160,7 @@ class GemWebcamStreamer:
 
     def detect_bbox(self, frame_bgr, W, H):
         from gem.utils.yolox_detector import detect_and_track
+
         bbx_xyxy_np, _ = detect_and_track(frame_bgr[None], self.yolox)
         bbx_xyxy = torch.from_numpy(bbx_xyxy_np).float()
         bbx_xyxy[:, [0, 2]] = bbx_xyxy[:, [0, 2]].clamp(0, W - 1)
@@ -138,10 +174,9 @@ class GemWebcamStreamer:
             self.K = estimate_K(W, H)
 
         bbx_xys = self.detect_bbox(frame_rgb, W, H)
-        vitpose = run_vitpose_onnx(self.vitpose_runner, self.vitpose_backend,
-                                   frame_rgb[None], bbx_xys[None])
+        vitpose = run_vitpose_onnx(self.vitpose_runner, self.vitpose_backend, frame_rgb[None], bbx_xys[None])
         kp2d = vitpose[0] if isinstance(vitpose, tuple) else vitpose
-        kp2d = torch.as_tensor(kp2d)[0]                   # [77,3]
+        kp2d = torch.as_tensor(kp2d)[0]  # [77,3]
 
         self.buf_kp2d.append(kp2d)
         self.buf_bbx.append(bbx_xys)
@@ -152,19 +187,17 @@ class GemWebcamStreamer:
         obs = torch.stack(list(self.buf_kp2d)).unsqueeze(0)
         bbx = torch.stack(list(self.buf_bbx)).unsqueeze(0)
         K = self.K.repeat(L, 1, 1).unsqueeze(0)
-        f_imgseq = torch.zeros(1, L, 1024)                # no-imgfeat
+        f_imgseq = torch.zeros(1, L, 1024)  # no-imgfeat
         cam_angvel = compute_cam_angvel(torch.eye(3).repeat(L, 1, 1)).unsqueeze(0)  # static cam
 
-        batch = {"obs": obs, "bbx_xys": bbx, "K_fullimg": K,
-                 "f_imgseq": f_imgseq, "f_cam_angvel": cam_angvel}
+        batch = {"obs": obs, "bbx_xys": bbx, "K_fullimg": K, "f_imgseq": f_imgseq, "f_cam_angvel": cam_angvel}
         pred_x, _pred_cam = run_denoiser_onnx(self.denoiser_runner, self.denoiser_backend, batch)
 
         self._ensure_decoder()
         decode_dict = self._endecoder.decode(pred_x)
 
-        # WORLD (gravity-aligned) root orientation, like the offline pipeline.
-        # decode_dict["global_orient"] is camera-frame; fuse to gravity-view so the
-        # robot doesn't pitch/tip to a tilted camera "up".
+        # decode_dict["global_orient"] is camera-frame; fuse to the gravity-aligned
+        # view so the robot doesn't pitch to match a tilted camera "up".
         world_global_orient = decode_dict["global_orient"][0, -1].cpu()  # fallback
         if "global_orient_gv" in decode_dict and "local_transl_vel" in decode_dict:
             gp = self._get_body_params_w_Rt_v2(
@@ -175,11 +208,12 @@ class GemWebcamStreamer:
             )
             world_global_orient = gp["global_orient"][0, -1].cpu()
 
-        soma = {"body_pose": decode_dict["body_pose"][0, -1].cpu(),
-                "global_orient": world_global_orient}
-        for k in ("identity_coeffs", "scale_params"):
-            if k in decode_dict:
-                soma[k] = decode_dict[k][0, -1].cpu()
+        soma = {
+            "body_pose": decode_dict["body_pose"][0, -1].cpu(),
+            "global_orient": world_global_orient,
+            "identity_coeffs": decode_dict["identity_coeffs"][0, -1].cpu(),
+            "scale_params": decode_dict["scale_params"][0, -1].cpu(),
+        }
         return kp2d, soma
 
 
@@ -194,6 +228,13 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--gemx-root", default=GEMX_ROOT, help="GEM-X repo root (or set $GEMX_ROOT)")
     ap.add_argument("--source", default="0", help="Webcam index (e.g. 0) or video file path")
+    ap.add_argument("--resolution", default=None, help="Request capture resolution for a camera, e.g. 1280x720")
+    ap.add_argument(
+        "--cap-fps",
+        type=float,
+        default=None,
+        help="Request capture fps for a camera (see v4l2-ctl --list-formats-ext)",
+    )
     ap.add_argument("--window", type=int, default=120, help="Rolling window length")
     ap.add_argument("--no-imgfeat", action="store_true", help="Skip SAM3DB image features (faster)")
     ap.add_argument("--kp-only", action="store_true", help="2D keypoints only (skip denoiser/decode)")
@@ -202,30 +243,41 @@ def main():
     ap.add_argument("--save", default=None, help="Optional path to save 2D-overlay preview mp4")
     ap.add_argument("--stream-sonic", action="store_true", help="Publish SMPL v3 stream to SONIC")
     ap.add_argument("--port", type=int, default=5556, help="ZMQ PUB port for SONIC stream")
-    ap.add_argument("--sonic-root", default=None, help="SONIC repo root (only if run outside the repo)")
-    ap.add_argument("--smooth", type=float, default=0.75,
-                    help="Temporal smoothing of streamed SMPL (0=off, 0.6-0.85 smoother)")
+    ap.add_argument(
+        "--sonic-root",
+        default=os.environ.get("SONIC_ROOT"),
+        help="SONIC repo root, or set $SONIC_ROOT (only needed when run outside the repo)",
+    )
+    ap.add_argument(
+        "--smooth", type=float, default=0.75, help="Temporal smoothing of streamed SMPL (0=off, 0.6-0.85 smoother)"
+    )
     args = ap.parse_args()
 
     if not args.gemx_root:
         raise SystemExit("Provide --gemx-root <GEM-X repo root> or set GEMX_ROOT.")
 
-    cap = _open_source(args.source)
+    cap = _open_source(args.source, resolution=args.resolution, cap_fps=args.cap_fps)
     W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 640
     H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 480
     src_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    Log.info(f"[webcam] source={args.source} {W}x{H} @ ~{src_fps:.1f}fps")
+    Log.info(f"[webcam] source={args.source} negotiated {W}x{H} @ ~{src_fps:.1f}fps")
+    if args.resolution and f"{W}x{H}" != args.resolution.lower():
+        Log.info(f"[webcam] note: requested {args.resolution}, camera gave {W}x{H}")
 
-    streamer = GemWebcamStreamer(args.gemx_root, window=args.window,
-                                 no_imgfeat=args.no_imgfeat or True)
+    streamer = GemWebcamStreamer(args.gemx_root, window=args.window, no_imgfeat=args.no_imgfeat or True)
 
     converter, publisher = None, None
     if args.stream_sonic:
-        from soma_to_smpl import SomaToSmpl, SonicV3Publisher
         from gem.utils.soma_utils.soma_layer import SomaLayer
-        soma_layer = SomaLayer(data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
-                               low_lod=True, device="cuda",
-                               identity_model_type="mhr", mode="warp")
+        from soma_to_smpl import SomaToSmpl, SonicV3Publisher
+
+        soma_layer = SomaLayer(
+            data_root=str(Path(args.gemx_root) / "inputs" / "soma_assets"),
+            low_lod=True,
+            device="cuda",
+            identity_model_type="mhr",
+            mode="warp",
+        )
         converter = SomaToSmpl(soma_layer, device="cuda", smooth=args.smooth, sonic_root=args.sonic_root)
         publisher = SonicV3Publisher(port=args.port, sonic_root=args.sonic_root)
         Log.info(f"[webcam] streaming SMPL v3 to SONIC on tcp://*:{args.port}")
@@ -251,8 +303,11 @@ def main():
             now = time.time()
             inst_fps = 1.0 / max(1e-6, now - t_last)
             t_last = now
-            print(f"\r[webcam] frame {n} | {inst_fps:5.1f} fps | "
-                  f"soma={'yes' if soma else 'warmup/kp-only'}", end="", flush=True)
+            print(
+                f"\r[webcam] frame {n} | {inst_fps:5.1f} fps | " f"soma={'yes' if soma else 'warmup/kp-only'}",
+                end="",
+                flush=True,
+            )
 
             if writer is not None or args.show:
                 vis = _draw_overlay(frame_bgr, kp2d)


### PR DESCRIPTION
## Summary
Adds a self-contained example under `gear_sonic/examples/live_camera_teleop/`
that drives the Unitree G1 from a **live webcam** using GEM-X 3D human pose
estimation, streamed into SONIC's existing ZMQ interface.

- `webcam_stream.py` — real-time GEM-X loop (YOLOX → VitPose → GEM denoiser)
  over a rolling window; decodes per-frame SOMA and streams to SONIC.
- `soma_to_smpl.py` — converts SOMA (77 joints) → SMPL (24, root-local,
  gravity-aligned) and publishes Protocol v3 for SONIC's `smpl` encoder,
  matching SONIC's `process_smpl_joints` convention exactly. Optional temporal
  smoothing.
- `soma_pt_to_sonic_v3.py` — offline verify (replays a saved `hpe_results.pt`,
  no camera).
- `README.md` — prerequisites, run commands, options, limitations.

GEM-X is an **optional external dependency** (not bundled); scripts point at it
via `--gemx-root` / `$GEMX_ROOT`. When run inside this repo, `gear_sonic` is
imported natively; a byte-identical fallback packer is included so the example
degrades gracefully if `gear_sonic` isn't importable.

## Test plan
- [ ] `run_sim_loop.py` + `deploy.sh --input-type zmq ... sim`, then
      `webcam_stream.py --stream-sonic` → G1 tracks the operator in MuJoCo.
- [ ] Camera-free path: `soma_pt_to_sonic_v3.py --pt hpe_results.pt` streams and
      tracks in sim.