### PR TITLE
Update Isaac Teleop onboarding ordering and setup guidance

### DIFF
--- a/docs/source/tutorials/isaac_teleop_publisher_setup.md
+++ b/docs/source/tutorials/isaac_teleop_publisher_setup.md
@@ -1,16 +1,16 @@
 # Isaac Teleop Setup (CloudXR / DeviceIO, in-process)
 
-This page documents the Isaac Teleop / CloudXR bring-up for **G1 with a Thor backpack** that drives `GR00T-WholeBodyControl` directly from the headset — no separate publisher container, no host `~/.cloudxr` sharing. The CloudXR runtime is hosted **in-process** by `pico_manager_thread_server.py --input-source isaac-teleop` via the `isaacteleop[cloudxr]` Python package.
+This page documents the Isaac Teleop / CloudXR bring-up for **G1 with a Thor backpack** that drives `GR00T-WholeBodyControl` directly from the headset. Using `pico_manager_thread_server.py --input-source isaac-teleop`, the CloudXR runtime is hosted **in-process** via the `isaacteleop[cloudxr]` Python package.
 
 ```{admonition} Scope
 :class: important
-This workflow is currently documented and supported only for **G1 + Thor backpack**.
+Real-robot deployment is supported only on **G1 + Thor backpack**. Sim2Sim (MuJoCo) can run on both Thor and x86_64 workstations.
 ```
 
 ## Prerequisites
 
-1. **Completed the [Quick Start](../getting_started/quickstart.md)** — you can run the sim2sim loop (includes [installing the deployment](../getting_started/installation_deploy.md) and [downloading model checkpoints](../getting_started/download_models.md)).
-2. **Completed the [VR Teleop Setup](../getting_started/vr_teleop_setup.md)** — `.venv_teleop` is ready and `install_pico.sh` has been run on Thor.
+1. **Completed the [Quick Start](../getting_started/quickstart.md)** — you can run the Sim2Sim loop (includes [installing the deployment](../getting_started/installation_deploy.md) and [downloading model checkpoints](../getting_started/download_models.md)).
+2. **Completed the [VR Teleop Setup](../getting_started/vr_teleop_setup.md)** — `.venv_teleop` is ready and `install_pico.sh` has been run (on Thor for real-robot deployment; on your workstation for Sim2Sim).
 
 This page is a condensed, repo-specific version of the upstream [Isaac Teleop](https://nvidia.github.io/IsaacTeleop/) docs:
 
@@ -23,14 +23,11 @@ Install the prerequisites on Thor (skip any you've already done for the rest of 
 
 ```bash
 sudo apt install -y build-essential curl git-lfs
-
-ARCH=$(uname -m)
-curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${ARCH}.sh"
-bash "Miniforge3-Linux-${ARCH}.sh" -b -p "$HOME/miniforge3"
-"$HOME/miniforge3/bin/conda" init
-source ~/.bashrc
-
 git lfs install
+```
+
+```{note}
+The remainder of this step (max power mode, thermal check) uses Thor/Jetson-specific tools. If you are running Sim2Sim (MuJoCo) on an x86_64 workstation instead of real G1 hardware, skip ahead to Step 2.
 ```
 
 For Thor performance, enable max power mode before teleoperation:
@@ -46,9 +43,13 @@ Optional thermal / over-current check:
 cat /sys/class/hwmon/hwmon*/oc*_event_cnt
 ```
 
-## Step 2: Install `isaacteleop[cloudxr]`
+## Step 2: Confirm `isaacteleop[cloudxr]` Installed
 
-`install_pico.sh` (run from the [VR Teleop Setup](../getting_started/vr_teleop_setup.md) Step 3) installs the `isaacteleop[cloudxr]` package into `.venv_teleop` from the public NVIDIA index:
+```{note}
+This step is a checkpoint, not a new action. `install_pico.sh`, run during [VR Teleop Setup](../getting_started/vr_teleop_setup.md) Step 3, already installs `isaacteleop[cloudxr]`. If that step is complete, skip to Step 3 below; otherwise, complete it before continuing.
+```
+
+For reference, `install_pico.sh` installs the package from the public NVIDIA index:
 
 ```bash
 # Already wired into install_pico.sh; shown here for reference
@@ -58,24 +59,7 @@ uv pip install 'isaacteleop[cloudxr]~=1.3.0' --prerelease=allow \
 
 It also seeds `~/cloudxr.env` with `NV_DEVICE_PROFILE=Quest3` (override by editing the file). `CloudXRLauncher` reads this on startup.
 
-## Step 3: Connect the XR Client
-
-The streamer launches the CloudXR runtime as a subprocess of the Python loop the first time you start it (Step 4). Until you connect the headset, `IsaacTeleopClient.start_streaming()` will retry quietly with `"no XR session yet"`.
-
-- Open the [Isaac Teleop Web Client](https://nvidia.github.io/IsaacTeleop/client/) in the headset browser
-- Enter the IP address of the Thor host
-- Accept the self-signed certificate at `https://<thor-ip>:48322`
-- Return to the client page and click **Connect**
-
-For quick validation, the same client URL can also be opened in a desktop browser.
-
-If you prefer to run the WebXR client from source instead of the hosted client, follow the CloudXR/WebXR build instructions linked from the [Isaac Teleop Quick Start](https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html).
-
-```{important}
-The streamer will fail to acquire OpenXR until the XR client is connected. Either connect the headset first, or start the streamer and watch for the `Isaac Teleop session initialized.` log line once you do.
-```
-
-## Step 4: Start the C++ Deployment
+## Step 3: Start the C++ Deployment
 
 From `gear_sonic_deploy/`:
 
@@ -85,11 +69,18 @@ export TensorRT_ROOT=$HOME/TensorRT   # only if not already in ~/.bashrc
 
 # inside the container (setup_env.sh is sourced automatically):
 just build                            # first run only
-./deploy.sh --input-type zmq_manager real
+
+# run one of these:
+./deploy.sh --input-type zmq_manager real   # real robot
+./deploy.sh --input-type zmq_manager sim    # Sim2Sim (MuJoCo)
 # Wait until you see "Init done"
 ```
 
-## Step 5: Launch the Teleop Streamer
+```{note}
+For Sim2Sim, first start the MuJoCo simulator on the host as shown in the [Quick Start](../getting_started/quickstart.md) Sim2Sim section, or the deployment will have nothing to control.
+```
+
+## Step 4: Launch the Teleop Streamer
 
 From the **repo root**:
 
@@ -102,9 +93,23 @@ python gear_sonic/scripts/pico_manager_thread_server.py --manager \
 #   --vis_vr3pt --vis_smpl
 ```
 
-Watch the streamer logs for `Isaac Teleop session initialized.` — that means CloudXR + DeviceIO are both up. The streamer then prints `Manager controls: A+X=toggle mode, A+B+X+Y=start/stop policy` once the headset is connected and body data starts flowing.
+On startup the streamer brings up the in-process CloudXR runtime and logs `Isaac Teleop session initialized.`, then repeats `waiting for Isaac Teleop body data (connect the headset to CloudXR)...` until you connect the client in Step 5.
 
-For controls and calibration, see [VR Whole-Body Teleop](vr_wholebody_teleop.md#pico-controls).
+## Step 5: Connect the XR Client
+
+Connecting the client starts the body-data stream the streamer is waiting for.
+
+- Open the [Isaac Teleop Web Client](https://nvidia.github.io/IsaacTeleop/client/) in the headset browser
+- Enter the IP address of the host running the streamer
+- Accept the self-signed certificate at `https://<host-ip>:48322`
+- On Thor, change **Video Codec** from the default **AV1** to **H.264** or **H.265 (HEVC)**.
+- Return to the client page and click **Connect**
+
+Once connected, stand in the [calibration pose](vr_wholebody_teleop.md#calibration-pose) and press **A+B+X+Y** on the PICO controllers to start the policy; the first press also runs the startup calibration and enters PLANNER (locomotion) mode. Then press **A+X** to switch to POSE mode for whole-body teleop, where your motion maps directly to the robot. See [Complete PICO Controls](vr_wholebody_teleop.md#pico-controls) for the other modes and the emergency stop.
+
+For quick validation, the same client URL can also be opened in a desktop browser.
+
+If you prefer to run the WebXR client from source instead of the hosted client, follow the CloudXR/WebXR build instructions linked from the [Isaac Teleop Quick Start](https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html).
 
 ## Step 6: Start Camera Visualization
 
@@ -161,13 +166,17 @@ This should also be consistent with the [instructions found at IsaacTeleop](http
 
 In this setup, that error usually means the XR client is not connected yet. Re-check:
 
-- The headset / web client is fully connected to `https://<thor-ip>:48322`
+- The headset / web client is fully connected to `https://<host-ip>:48322`
 - The CloudXR runtime subprocess is still alive (look for the `Isaac Teleop session initialized.` log)
 - `~/cloudxr.env` exists and has the right `NV_DEVICE_PROFILE` for your headset
 
+### Client connects but the video encoder fails to initialize
+
+On Thor, this usually means the client's **Video Codec** is still set to its default, **AV1**. Switch the client to **H.264** or **H.265 (HEVC)** and reconnect (see Step 5).
+
 ### `gear_sonic_deploy` build error
 
-If `just build` fails, rebuild from scratch inside the container (Step 4):
+If `just build` fails, rebuild from scratch inside the container (Step 3):
 
 ```bash
 rm -rf build
@@ -182,7 +191,7 @@ Re-run `install_pico.sh` to reinstall `isaacteleop[cloudxr]~=1.3.0` into `.venv_
 
 The streamer logs `[IsaacTeleopReader] No DeviceIO data for 5.0s, flagging disconnect` if the headset stops feeding body data. Confirm:
 
-1. The headset is still connected to CloudXR (Step 3).
+1. The headset is still connected to CloudXR (Step 5).
 2. The Pico body trackers are paired and calibrated (see [VR Teleop Setup → Motion Tracker Setup](../getting_started/vr_teleop_setup.md)).
 3. The first time the schema runs, watch for `[IsaacTeleopReader] Unrecognised body_data schema: type=...` — if you see it, the upstream `FullBodyTrackerPico.get_body_pose().data` shape changed and `_body_data_to_24x7()` in `gear_sonic/utils/teleop/input_readers.py` needs an extra branch for the new layout.
 


### PR DESCRIPTION
Reorders the flow so the XR client connects after the deployment and streamer, scopes the Thor-only steps so Sim2Sim runs on x86_64, and corrects the deploy commands, streamer startup logs, and PICO control steps.