### PR TITLE
Fix duplicate palm geom in left hand MJCF causing 2x mass

### DIFF
--- a/decoupled_wbc/dexmg/gr00trobocasa/robocasa/models/assets/robots/unitree_g1/g1_threefinger_left_hand.xml
+++ b/decoupled_wbc/dexmg/gr00trobocasa/robocasa/models/assets/robots/unitree_g1/g1_threefinger_left_hand.xml
@@ -41,8 +41,6 @@
         <site name="grip_site_cylinder" pos="0 0 0" quat="-0.5 -0.5 -0.5 0.5" size="0.005 0.5"
           rgba="0 1 0 0.3" type="cylinder" group="1" />
       </body>
-      <geom pos="0.0415 0.003 0" quat="1 0 0 0" type="mesh" rgba="0.1 0.1 0.1 1"
-        mesh="left_hand_palm_link" />
       <body name="left_hand_thumb_0_link" pos="0.067 0.003 0">
         <inertial pos="-0.000884246 -0.00863407 0.000944293"
           quat="0.462991 0.643965 -0.460173 0.398986" mass="0.0862366"


### PR DESCRIPTION
## Problem

`g1_threefinger_left_hand.xml` has three `<geom>` elements referencing the 
`left_hand_palm_link` mesh on the palm body. The right hand XML only has two.

MuJoCo computes body mass from mesh volume for every geom without `density="0"`, 
so the left palm accumulated double the mass (0.822 kg vs 0.411 kg for the right).

This causes the left arm to experience ~22% more gravity torque than the right 
under identical PD gains, producing asymmetric behavior in bimanual tasks.

## Fix

Remove the duplicate `<geom>` that appeared after the `eef` child body. 
The remaining two geoms (one visual with `density="0"`, one collision) match 
the structure of `g1_threefinger_right_hand.xml`.
