### PR TITLE
Enable recording and correct replay of custom reference motions

### DIFF
--- a/gear_sonic_deploy/deploy.sh
+++ b/gear_sonic_deploy/deploy.sh
@@ -211,6 +211,7 @@ show_usage() {
     echo "  --input-type TYPE       Set the input type (default: zmq_manager)"
     echo "  --output-type TYPE      Set the output type (default: ros2)"
     echo "  --zmq-host HOST         Set the ZMQ host (default: localhost)"
+    echo "  --enable-motion-recording  Record ZMQ/planner motions to reference/recorded_motion/"
     echo ""
     echo "Interface modes:"
     echo "  sim              Use loopback interface for simulation (MuJoCo)"
@@ -251,6 +252,7 @@ MOTION_DATA="$MOTION_DATA_DEFAULT"
 INPUT_TYPE="$INPUT_TYPE_DEFAULT"
 OUTPUT_TYPE="$OUTPUT_TYPE_DEFAULT"
 ZMQ_HOST="$ZMQ_HOST_DEFAULT"
+EXTRA_ARGS=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -314,6 +316,10 @@ while [[ $# -gt 0 ]]; do
             fi
             ZMQ_HOST="$2"
             shift 2
+            ;;
+        --enable-motion-recording)
+            EXTRA_ARGS="$EXTRA_ARGS --enable-motion-recording"
+            shift
             ;;
         sim|real)
             INTERFACE_MODE="$1"
@@ -380,9 +386,8 @@ CHECKPOINT_ENCODER="${CHECKPOINT}_encoder.onnx"
 # ZMQ_HOST is already set from argument parsing above
 
 # Additional flags for simulation mode
-EXTRA_ARGS=""
 if [[ "$ENV_TYPE" == "sim" ]]; then
-    EXTRA_ARGS="--disable-crc-check"
+    EXTRA_ARGS="$EXTRA_ARGS --disable-crc-check"
     echo -e "${YELLOW}📋 Simulation mode: CRC check will be disabled${NC}"
     echo ""
 fi

--- a/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
+++ b/gear_sonic_deploy/src/g1/g1_deploy_onnx_ref/src/g1_deploy_onnx_ref.cpp
@@ -2384,8 +2384,22 @@ class G1Deploy {
       // Set the encode_mode for all loaded reference motions based on encoder availability
       std::cout << "Setting encode_mode for " << motion_reader_.motions.size() << " loaded reference motions..." << std::endl;
       for (auto& motion : motion_reader_.motions) {
-        motion->SetEncodeMode(initial_encoder_mode_);
-        std::cout << "  Motion '" << motion->name << "' encode_mode set to: " << initial_encoder_mode_ << std::endl;
+        const bool has_smpl_reference =
+          motion->GetNumSmplJoints() > 0 &&
+          motion->GetNumSmplPoses() > 0 &&
+          motion->GetNumJoints() >= 29 &&
+          motion->GetNumBodyQuaternions() > 0;
+
+        const int motion_encoder_mode =
+          (initial_encoder_mode_ >= 0 && has_smpl_reference) ? 2 : initial_encoder_mode_;
+
+        motion->SetEncodeMode(motion_encoder_mode);
+        std::cout << "  Motion '" << motion->name << "' encode_mode set to: "
+                  << motion_encoder_mode;
+        if (has_smpl_reference && initial_encoder_mode_ >= 0) {
+          std::cout << " (SMPL reference detected)";
+        }
+        std::cout << std::endl;
       }
       
       // Set encode_mode for planner motion


### PR DESCRIPTION
## What
Two small changes that let users author and correctly replay their own
reference motions (e.g. recorded from PICO 4 whole-body teleop):

- **`deploy.sh`**: expose `--enable-motion-recording` (already supported by
  the binary, but not reachable through `deploy.sh`). Also fixes `sim` mode
  overwriting user-supplied extra args.
- **`g1_deploy_onnx_ref.cpp`**: when a loaded reference motion carries
  complete SMPL reference data (and an encoder is loaded), set its
  `encode_mode` to 2 (SMPL) automatically. Motions without SMPL data are
  unchanged.

## Why
Recording your own motion and replaying it was not possible end-to-end via
`deploy.sh`:
- The recording flag was not exposed, so `deploy.sh` had to be bypassed.
- On replay, a motion with SMPL data started in the default encoder mode and
  relied on runtime fallback, which picks the first mode whose observations
  happen to be available — this can silently select the wrong mode. Setting
  mode 2 up front from the data makes replay correct and deterministic.

## How to try
Teleoperate the real robot from a PICO 4 and record the streamed motion:

```sh
# Record
./deploy.sh --input-type zmq_manager --enable-motion-recording real

# Replay
./deploy.sh --motion-data reference/recorded_motion/<date> real
```

Recordings are saved under `reference/recorded_motion/YYYYMMDD/`. A replayed
motion with SMPL data runs in encoder mode 2 automatically (look for
`(SMPL reference detected)` in the startup log).
