### PR TITLE
Declare open3d and vector_quantize_pytorch in training extra

### DIFF
--- a/gear_sonic/pyproject.toml
+++ b/gear_sonic/pyproject.toml
@@ -100,6 +100,8 @@ training = [
     "accelerate>=1.3.0",
     "tensorboard",
     "smpl_sim @ git+https://github.com/ZhengyiLuo/SMPLSim.git",
+    "open3d",
+    "vector_quantize_pytorch",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Both are imported by the training path but declared in no dependency group, so training fails on a fresh install following the documented setup.

open3d - unguarded top-level import at
gear_sonic/utils/motion_lib/torch_humanoid_batch.py:18:

  ModuleNotFoundError: No module named 'open3d'

Import chain: train_agent_trl.py:321 -> modular_tracking_env_cfg.py:18 -> mdp/__init__.py:6 -> mdp/commands.py:35 -> motion_lib_robot.py:2 -> torch_humanoid_batch.py:18

vector_quantize_pytorch - resolved at runtime from a Hydra _target_ string via importlib in gear_sonic/trl/utils/common.py:16, reached from universal_token_modules.py:234 when constructing the FSQ quantizer:

  ModuleNotFoundError: No module named 'vector_quantize_pytorch'

check_environment.py --training reports "All checks passed" immediately before both failures.

Verified the fix on Isaac Sim 5.1.0.0 / Isaac Lab 2.3.0 / Python 3.11.15.