### PR TITLE
Add setup_network.py for Unitree G1 network configuration

### DIFF
--- a/docs/source/references/decoupled_wbc.md
+++ b/docs/source/references/decoupled_wbc.md
@@ -66,12 +66,12 @@ Once inside the container, the control policies can be launched directly.
 python decoupled_wbc/control/main/teleop/run_g1_control_loop.py
 ```
 
-- Real robot: The G1 communicates exclusively over a **dedicated wired ethernet cable** between the host and the robot (DDS motor control at 500 Hz + camera stream — WiFi cannot substitute). Connect the cable, then assign the required static IP (`192.168.123.222/24`) to that interface:
+- Real robot: The G1 communicates exclusively over a **dedicated wired ethernet cable** between the host and the robot (DDS motor control at 500 Hz + camera stream — WiFi cannot substitute). Connect the cable, then assign the required static IP (`192.168.123.222`, subnet mask `255.255.255.0`) to that interface:
 
   ```bash
   python gear_sonic_deploy/scripts/setup_network.py
   # or, if you know the interface name:
-  python gear_sonic_deploy/scripts/setup_network.py -i enp5s0
+  python gear_sonic_deploy/scripts/setup_network.py -i <INTERFACE>
   ```
 
   The script identifies wired ethernet interfaces, configures the static IP via NetworkManager, and pings the robot to verify connectivity. The host's WiFi can remain connected to the lab network on a separate interface for SSH/internet access. See the [G1 SDK Development Guide](https://support.unitree.com/home/en/G1_developer) for additional reference. Once the interface is configured:

--- a/docs/source/references/decoupled_wbc.md
+++ b/docs/source/references/decoupled_wbc.md
@@ -66,11 +66,19 @@ Once inside the container, the control policies can be launched directly.
 python decoupled_wbc/control/main/teleop/run_g1_control_loop.py
 ```
 
-- Real robot: Ensure the host machine network is configured per the [G1 SDK Development Guide](https://support.unitree.com/home/en/G1_developer) and set a static IP at `192.168.123.222`, subnet mask `255.255.255.0`:
+- Real robot: Connect an ethernet cable between the host machine and the G1 robot, then assign a static IP (`192.168.123.222/24`) to that interface using the provided setup script:
 
-```bash
-python decoupled_wbc/control/main/teleop/run_g1_control_loop.py --interface real
-```
+  ```bash
+  python gear_sonic_deploy/scripts/setup_network.py
+  # or, if you know the interface name:
+  python gear_sonic_deploy/scripts/setup_network.py -i enp5s0
+  ```
+
+  The script detects available ethernet interfaces, configures the static IP via NetworkManager, and verifies connectivity to the robot. See the [G1 SDK Development Guide](https://support.unitree.com/home/en/G1_developer) for additional network reference. Once the interface is configured:
+
+  ```bash
+  python decoupled_wbc/control/main/teleop/run_g1_control_loop.py --interface real
+  ```
 
 Keyboard shortcuts (terminal window):
 - `]`: Activate policy

--- a/docs/source/references/decoupled_wbc.md
+++ b/docs/source/references/decoupled_wbc.md
@@ -66,7 +66,7 @@ Once inside the container, the control policies can be launched directly.
 python decoupled_wbc/control/main/teleop/run_g1_control_loop.py
 ```
 
-- Real robot: Connect an ethernet cable between the host machine and the G1 robot, then assign a static IP (`192.168.123.222/24`) to that interface using the provided setup script:
+- Real robot: The G1 communicates exclusively over a **dedicated wired ethernet cable** between the host and the robot (DDS motor control at 500 Hz + camera stream — WiFi cannot substitute). Connect the cable, then assign the required static IP (`192.168.123.222/24`) to that interface:
 
   ```bash
   python gear_sonic_deploy/scripts/setup_network.py
@@ -74,7 +74,7 @@ python decoupled_wbc/control/main/teleop/run_g1_control_loop.py
   python gear_sonic_deploy/scripts/setup_network.py -i enp5s0
   ```
 
-  The script detects available ethernet interfaces, configures the static IP via NetworkManager, and verifies connectivity to the robot. See the [G1 SDK Development Guide](https://support.unitree.com/home/en/G1_developer) for additional network reference. Once the interface is configured:
+  The script identifies wired ethernet interfaces, configures the static IP via NetworkManager, and pings the robot to verify connectivity. The host's WiFi can remain connected to the lab network on a separate interface for SSH/internet access. See the [G1 SDK Development Guide](https://support.unitree.com/home/en/G1_developer) for additional reference. Once the interface is configured:
 
   ```bash
   python decoupled_wbc/control/main/teleop/run_g1_control_loop.py --interface real

--- a/docs/source/tutorials/data_collection.md
+++ b/docs/source/tutorials/data_collection.md
@@ -17,6 +17,7 @@ The tested and supported camera setup uses **Luxonis OAK cameras** (OAK-D, OAK-1
 1. **Completed the [Quick Start](../getting_started/quickstart.md)** — you can run the sim2sim loop (includes [installing the deployment](../getting_started/installation_deploy.md) and [downloading model checkpoints](../getting_started/download_models.md)).
 2. **Completed the [VR Teleop Setup](../getting_started/vr_teleop_setup.md)** — PICO hardware is calibrated and `.venv_teleop` is ready.
 3. **Camera server running on the robot** — see [Camera Server Setup](#camera-server-setup-on-robot) below. For simulation, the MuJoCo sim loop publishes camera images automatically — no camera server needed.
+4. **Real robot only — network interface configured** — ethernet cable connected between host and G1, static IP assigned via `python gear_sonic_deploy/scripts/setup_network.py`. The workstation must reach the robot at `192.168.123.164` before running the camera viewer or data exporter.
 ```
 
 ---

--- a/docs/source/tutorials/vla_inference.md
+++ b/docs/source/tutorials/vla_inference.md
@@ -70,7 +70,17 @@ inference dependencies.
 The camera server should be running as a systemd service on the robot.
 See [Data Collection](data_collection.md) for camera server setup.
 
-### 4. C++ Deploy
+### 4. Network Interface (Real Robot)
+
+Connect an ethernet cable between the host and the G1 robot, then assign the static IP:
+
+```bash
+python gear_sonic_deploy/scripts/setup_network.py
+```
+
+The workstation must reach the robot at `192.168.123.164` before running inference.
+
+### 5. C++ Deploy
 
 The `gear_sonic_deploy` binary must be built. See the main README.
 

--- a/docs/source/tutorials/vr_wholebody_teleop.md
+++ b/docs/source/tutorials/vr_wholebody_teleop.md
@@ -34,6 +34,7 @@ You **must wear tight-fitting pants or leggings** to guarantee line-of-sight for
 
 1. **Completed the [Quick Start](../getting_started/quickstart.md)** — you can run the sim2sim loop (includes [installing the deployment](../getting_started/installation_deploy.md) and [downloading model checkpoints](../getting_started/download_models.md)).
 2. **Completed the [VR Teleop Setup](../getting_started/vr_teleop_setup.md)** — `.venv_teleop` is ready. For the default path, PICO hardware is installed, calibrated, and connected. For Isaac Teleop / CloudXR, the `isaacteleop[cloudxr]` package is also installed (handled by `install_pico.sh`) and the headset connects to the in-process CloudXR runtime — see [Isaac Teleop Setup](isaac_teleop_publisher_setup.md).
+3. **Real robot only — network interface configured** — ethernet cable connected between host and G1, static IP assigned via `python gear_sonic_deploy/scripts/setup_network.py`. See [Network Setup](../references/decoupled_wbc.md#running-the-control-stack) for details. Skip for sim.
 
 ---
 

--- a/docs/source/user_guide/teleoperation.md
+++ b/docs/source/user_guide/teleoperation.md
@@ -4,7 +4,8 @@ This guide covers best practices during whole-body teleoperation.
 
 ```{admonition} Prerequisites
 :class: note
-Complete the [Quick Start](../getting_started/quickstart), [PICO Setup](../getting_started/vr_teleop_setup), and [Teleop Setup](../tutorials/vr_wholebody_teleop)
+Complete the [Quick Start](../getting_started/quickstart), [PICO Setup](../getting_started/vr_teleop_setup), and [Teleop Setup](../tutorials/vr_wholebody_teleop).
+For real robot: ethernet cable connected and static IP assigned — run `python gear_sonic_deploy/scripts/setup_network.py` before starting deployment.
 ```
 
 ## Overview

--- a/gear_sonic_deploy/scripts/setup_network.py
+++ b/gear_sonic_deploy/scripts/setup_network.py
@@ -16,7 +16,7 @@ subnet (192.168.123.0/24) rather than the entire interface.
 
 Usage:
     python3 setup_network.py                  # interactive robot + interface selection
-    python3 setup_network.py -i enp5s0        # skip interface selection
+    python3 setup_network.py -i enp5s0        # manual interface selection
 """
 
 import argparse

--- a/gear_sonic_deploy/scripts/setup_network.py
+++ b/gear_sonic_deploy/scripts/setup_network.py
@@ -5,9 +5,9 @@ Setup a network interface for communication with the Unitree G1 robot.
 Assigns a static IP to the selected ethernet interface so the host machine
 can communicate with the robot over the 192.168.123.x subnet.
 
-Requirements: Linux (Ubuntu 20.04/22.04/24.04), iproute2, sudo privileges.
+Requirements: Ubuntu 20.04 / 22.04 / 24.04, NetworkManager (nmcli), sudo privileges.
 ufw is optional — if present, a scoped allow rule is added for the robot
-interface rather than disabling the firewall globally.
+subnet rather than the entire interface.
 
 Usage:
     python3 setup_network.py                  # interactive robot + interface selection
@@ -29,11 +29,15 @@ ROBOT_CONFIGURATIONS = {
     "Unitree G1": {
         "ip_address": "192.168.123.222",
         "subnet_mask": "255.255.255.0",
+        "prefix_length": "24",
         "gateway": "",
-        "connection_name": "Unitree G1",
+        "connection_name": "unitree-g1-robot",
         "robot_ip_address": "192.168.123.164",
+        "robot_subnet": "192.168.123.0/24",
     },
 }
+
+SUPPORTED_UBUNTU_VERSIONS = {"20.04", "22.04", "24.04"}
 
 
 class Colors:
@@ -55,11 +59,50 @@ def print_error(msg: str) -> None:
     print(f"{Colors.RED}[ERROR]{Colors.NC} {msg}")
 
 
-def check_linux() -> None:
+def check_ubuntu() -> None:
     if platform.system() != "Linux":
         print_error(
             f"Unsupported OS: {platform.system()}. "
-            "This script requires Linux (Ubuntu 20.04/22.04/24.04)."
+            "This script requires Ubuntu 20.04 / 22.04 / 24.04."
+        )
+        sys.exit(1)
+
+    # Read /etc/os-release directly — works without lsb_release installed.
+    os_info: dict[str, str] = {}
+    try:
+        with open("/etc/os-release", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if "=" in line:
+                    k, _, v = line.partition("=")
+                    os_info[k] = v.strip('"')
+    except FileNotFoundError:
+        pass
+
+    distro_id = os_info.get("ID", "").lower()
+    version = os_info.get("VERSION_ID", "")
+
+    if distro_id != "ubuntu":
+        print_warning(
+            f"Detected distro: '{distro_id}' (expected Ubuntu). "
+            "This script is tested on Ubuntu only — proceed with caution."
+        )
+    elif version not in SUPPORTED_UBUNTU_VERSIONS:
+        print_warning(
+            f"Ubuntu {version} is not in the tested set "
+            f"({', '.join(sorted(SUPPORTED_UBUNTU_VERSIONS))}). "
+            "Proceeding anyway."
+        )
+    else:
+        print_info(f"Ubuntu {version} detected.")
+
+
+def check_nmcli() -> None:
+    if not shutil.which("nmcli"):
+        print_error(
+            "nmcli not found. NetworkManager is required to configure the interface "
+            "in a way that survives NM management.\n"
+            "Install with: sudo apt-get install network-manager"
         )
         sys.exit(1)
 
@@ -98,8 +141,7 @@ def select_robot_type() -> dict[str, str]:
                 config["robot_type"] = name
                 print_info(f"Selected: {name}")
                 print()
-                print_info(f"Host IP to assign : {config['ip_address']}")
-                print_info(f"Subnet mask       : {config['subnet_mask']}")
+                print_info(f"Host IP to assign : {config['ip_address']}/{config['prefix_length']}")
                 print_info(f"Robot IP (ping)   : {config['robot_ip_address']}")
                 print()
                 return config
@@ -125,11 +167,10 @@ def get_available_interfaces() -> list[tuple[str, str, str]]:
         iface = parts[1].strip()
         # Skip loopback and well-known virtual prefixes.
         if iface == "lo" or any(
-            iface.startswith(p) for p in ["docker", "veth", "br-", "virbr", "vmnet"]
+            iface.startswith(p) for p in ["docker", "veth", "br-", "virbr", "vmnet", "wl"]
         ):
             continue
 
-        # State
         state_result = run_command(["sudo", "ip", "link", "show", iface], check=False)
         state = "UNKNOWN"
         for sl in state_result.stdout.splitlines():
@@ -137,7 +178,6 @@ def get_available_interfaces() -> list[tuple[str, str, str]]:
                 state = sl.split("state")[1].strip().split()[0]
                 break
 
-        # Current IP
         ip_result = run_command(["sudo", "ip", "addr", "show", iface], check=False)
         ip_info = "No IP assigned"
         for il in ip_result.stdout.splitlines():
@@ -185,42 +225,10 @@ def select_interface() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Backup
+# Firewall — scoped to robot subnet, not the whole interface
 # ---------------------------------------------------------------------------
 
-def backup_config(config: dict[str, str], interface: str) -> str:
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
-    backup_file = f"/tmp/network_backup_{timestamp}.txt"
-    print_info(f"Backing up current interface config to {backup_file}")
-
-    with open(backup_file, "w", encoding="utf-8") as f:
-        f.write(f"# Network configuration backup - {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-        f.write(f"# Robot type : {config['robot_type']}\n")
-        f.write(f"# Interface  : {interface}\n")
-        f.write(f"# Host IP    : {config['ip_address']}\n")
-        f.write(f"# Subnet mask: {config['subnet_mask']}\n\n")
-
-        f.write("# Current IP addresses:\n")
-        r = run_command(["sudo", "ip", "addr", "show", interface], check=False)
-        for line in r.stdout.splitlines():
-            if "inet" in line:
-                f.write(line + "\n")
-
-        f.write("\n# Current routes for this interface:\n")
-        r = run_command(["sudo", "ip", "route", "show"], check=False)
-        for line in r.stdout.splitlines():
-            if interface in line:
-                f.write(line + "\n")
-
-    print_info(f"Backup saved: {backup_file}")
-    return backup_file
-
-
-# ---------------------------------------------------------------------------
-# Firewall — scoped rule, not global disable
-# ---------------------------------------------------------------------------
-
-def configure_firewall(interface: str) -> None:
+def configure_firewall(config: dict[str, str]) -> None:
     if not shutil.which("ufw"):
         print_warning("ufw not found — skipping firewall configuration.")
         return
@@ -230,52 +238,84 @@ def configure_firewall(interface: str) -> None:
         print_info("ufw is inactive — no firewall rules needed.")
         return
 
-    print_info(f"Adding scoped ufw rules for interface {interface} (robot subnet only)...")
-    in_result = run_command(["sudo", "ufw", "allow", "in", "on", interface], check=False)
-    out_result = run_command(["sudo", "ufw", "allow", "out", "on", interface], check=False)
+    robot_subnet = config["robot_subnet"]
+    print_info(f"Adding scoped ufw rules for robot subnet {robot_subnet}...")
+
+    in_result = run_command(
+        ["sudo", "ufw", "allow", "from", robot_subnet], check=False
+    )
+    out_result = run_command(
+        ["sudo", "ufw", "allow", "to", robot_subnet], check=False
+    )
 
     if in_result.returncode == 0 and out_result.returncode == 0:
-        print_info(f"ufw: allowed all traffic in/out on {interface}.")
+        print_info(f"ufw: allowed traffic to/from {robot_subnet}.")
     else:
         print_warning("Could not add ufw rules — robot communication may be blocked.")
-        print_warning("Run manually: sudo ufw allow in on <interface> && sudo ufw allow out on <interface>")
+        print_warning(
+            f"Run manually: sudo ufw allow from {robot_subnet} && sudo ufw allow to {robot_subnet}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# Interface configuration
+# Interface configuration via NetworkManager (nmcli)
+# Using nmcli ensures the static IP is NM-aware and won't be reverted by the
+# NetworkManager daemon, which manages wired interfaces by default on Ubuntu.
 # ---------------------------------------------------------------------------
 
 def configure_interface(config: dict[str, str], interface: str) -> None:
-    print_info(f"Configuring {interface} for {config['connection_name']}...")
+    conn_name = config["connection_name"]
+    ip_cidr = f"{config['ip_address']}/{config['prefix_length']}"
 
-    configure_firewall(interface)
+    print_info(f"Configuring {interface} for {config['robot_type']} via NetworkManager...")
 
-    # Flush existing addresses and bring the interface up.
-    run_command(["sudo", "ip", "addr", "flush", "dev", interface], check=False)
-    run_command(["sudo", "ip", "link", "set", interface, "up"])
-    time.sleep(1)
+    configure_firewall(config)
 
-    # Assign static IP.
-    cidr = sum(bin(int(x)).count("1") for x in config["subnet_mask"].split("."))
-    run_command(["sudo", "ip", "addr", "add", f"{config['ip_address']}/{cidr}", "dev", interface])
+    # Remove any existing profile with this connection name to avoid conflicts.
+    existing = run_command(
+        ["sudo", "nmcli", "connection", "show", conn_name], check=False
+    )
+    if existing.returncode == 0:
+        print_info(f"Removing existing NM profile '{conn_name}'...")
+        run_command(["sudo", "nmcli", "connection", "delete", conn_name], check=False)
 
-    # Add default route only when a gateway is specified.
+    # Create a new wired connection profile with a static IP.
+    add_cmd = [
+        "sudo", "nmcli", "connection", "add",
+        "type", "ethernet",
+        "con-name", conn_name,
+        "ifname", interface,
+        "ipv4.method", "manual",
+        "ipv4.addresses", ip_cidr,
+        "ipv6.method", "disabled",
+    ]
     if config["gateway"]:
-        run_command(
-            ["sudo", "ip", "route", "add", "default", "via", config["gateway"], "dev", interface],
-            check=False,
-        )
+        add_cmd += ["ipv4.gateway", config["gateway"]]
+
+    result = run_command(add_cmd, check=False)
+    if result.returncode != 0:
+        print_error(f"Failed to create NM connection profile:\n{result.stderr}")
+        sys.exit(1)
+
+    # Bring it up.
+    up_result = run_command(
+        ["sudo", "nmcli", "connection", "up", conn_name], check=False
+    )
+    if up_result.returncode != 0:
+        print_error(f"Failed to bring up connection '{conn_name}':\n{up_result.stderr}")
+        sys.exit(1)
 
     # Verify.
-    result = run_command(["sudo", "ip", "addr", "show", interface], check=False)
-    if config["ip_address"] in result.stdout:
+    time.sleep(1)
+    addr_result = run_command(["sudo", "ip", "addr", "show", interface], check=False)
+    if config["ip_address"] in addr_result.stdout:
         print_info("Interface configured successfully.")
         print_info(f"  Interface : {interface}")
-        print_info(f"  Host IP   : {config['ip_address']}/{cidr}")
+        print_info(f"  Host IP   : {ip_cidr}")
         if config["gateway"]:
             print_info(f"  Gateway   : {config['gateway']}")
     else:
-        print_error("Failed to assign IP address to interface.")
+        print_error("IP address was not assigned — check nmcli output above.")
         sys.exit(1)
 
 
@@ -315,7 +355,8 @@ def main() -> None:
 
     print_info("Starting network setup for robot communication.")
 
-    check_linux()
+    check_ubuntu()
+    check_nmcli()
     check_sudo()
 
     config = select_robot_type()
@@ -330,16 +371,21 @@ def main() -> None:
     else:
         interface = select_interface()
 
-    backup_config(config, interface)
     configure_interface(config, interface)
     check_interface_state(interface)
     ping_robot(config["robot_ip_address"])
 
     print_info("Network setup complete.")
-    print_info(f"Interface {interface} is ready for {config['connection_name']} communication.")
-    print_warning("Note: this configuration is not persistent and will reset on reboot.")
+    print_info(
+        f"Interface {interface} is configured for {config['robot_type']} communication.\n"
+        f"  Connection profile '{config['connection_name']}' is managed by NetworkManager\n"
+        f"  and will persist until the profile is deleted or the interface is reconfigured."
+    )
+    print_warning(
+        "Note: this assigns a static IP for the duration of the NM connection profile. "
+        "To remove it: sudo nmcli connection delete " + config["connection_name"]
+    )
 
 
 if __name__ == "__main__":
     main()
-

--- a/gear_sonic_deploy/scripts/setup_network.py
+++ b/gear_sonic_deploy/scripts/setup_network.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Setup a network interface for communication with the Unitree G1 robot.
+
+Assigns a static IP to the selected ethernet interface so the host machine
+can communicate with the robot over the 192.168.123.x subnet.
+
+Requirements: Linux (Ubuntu 20.04/22.04/24.04), iproute2, sudo privileges.
+ufw is optional — if present, a scoped allow rule is added for the robot
+interface rather than disabling the firewall globally.
+
+Usage:
+    python3 setup_network.py                  # interactive robot + interface selection
+    python3 setup_network.py -i enp5s0        # skip interface selection
+"""
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# Robot configurations — host IP is what gets assigned to the workstation NIC;
+# robot_ip_address is used only for the post-setup connectivity ping.
+# ---------------------------------------------------------------------------
+ROBOT_CONFIGURATIONS = {
+    "Unitree G1": {
+        "ip_address": "192.168.123.222",
+        "subnet_mask": "255.255.255.0",
+        "gateway": "",
+        "connection_name": "Unitree G1",
+        "robot_ip_address": "192.168.123.164",
+    },
+}
+
+
+class Colors:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    NC = "\033[0m"
+
+
+def print_info(msg: str) -> None:
+    print(f"{Colors.GREEN}[INFO]{Colors.NC} {msg}")
+
+
+def print_warning(msg: str) -> None:
+    print(f"{Colors.YELLOW}[WARNING]{Colors.NC} {msg}")
+
+
+def print_error(msg: str) -> None:
+    print(f"{Colors.RED}[ERROR]{Colors.NC} {msg}")
+
+
+def check_linux() -> None:
+    if platform.system() != "Linux":
+        print_error(
+            f"Unsupported OS: {platform.system()}. "
+            "This script requires Linux (Ubuntu 20.04/22.04/24.04)."
+        )
+        sys.exit(1)
+
+
+def check_sudo() -> None:
+    if not shutil.which("sudo"):
+        print_error("sudo not found. Please install sudo or run as root.")
+        sys.exit(1)
+    result = subprocess.run(["sudo", "-n", "true"], capture_output=True)
+    if result.returncode != 0:
+        print_info("Some commands require sudo. You may be prompted for your password.")
+
+
+def run_command(command: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(command, check=check, capture_output=True, text=True)
+
+
+# ---------------------------------------------------------------------------
+# Robot selection
+# ---------------------------------------------------------------------------
+
+def select_robot_type() -> dict[str, str]:
+    print_info("Select robot type:")
+    print()
+    robot_names = list(ROBOT_CONFIGURATIONS.keys())
+    for i, name in enumerate(robot_names, 1):
+        print(f"  {i}) {name}")
+    print()
+
+    while True:
+        try:
+            choice = int(input(f"Select robot type (1-{len(robot_names)}): "))
+            if 1 <= choice <= len(robot_names):
+                name = robot_names[choice - 1]
+                config = ROBOT_CONFIGURATIONS[name].copy()
+                config["robot_type"] = name
+                print_info(f"Selected: {name}")
+                print()
+                print_info(f"Host IP to assign : {config['ip_address']}")
+                print_info(f"Subnet mask       : {config['subnet_mask']}")
+                print_info(f"Robot IP (ping)   : {config['robot_ip_address']}")
+                print()
+                return config
+            print_error(f"Enter a number between 1 and {len(robot_names)}.")
+        except ValueError:
+            print_error("Invalid input. Enter a number.")
+
+
+# ---------------------------------------------------------------------------
+# Interface enumeration
+# ---------------------------------------------------------------------------
+
+def get_available_interfaces() -> list[tuple[str, str, str]]:
+    """Return [(name, state, ip_or_'No IP assigned'), ...] for physical NICs."""
+    result = run_command(["sudo", "ip", "link", "show"])
+    interfaces = []
+
+    for line in result.stdout.splitlines():
+        parts = line.split(":")
+        if not (parts[0].strip().isdigit() and len(parts) >= 2):
+            continue
+
+        iface = parts[1].strip()
+        # Skip loopback and well-known virtual prefixes.
+        if iface == "lo" or any(
+            iface.startswith(p) for p in ["docker", "veth", "br-", "virbr", "vmnet"]
+        ):
+            continue
+
+        # State
+        state_result = run_command(["sudo", "ip", "link", "show", iface], check=False)
+        state = "UNKNOWN"
+        for sl in state_result.stdout.splitlines():
+            if "state" in sl:
+                state = sl.split("state")[1].strip().split()[0]
+                break
+
+        # Current IP
+        ip_result = run_command(["sudo", "ip", "addr", "show", iface], check=False)
+        ip_info = "No IP assigned"
+        for il in ip_result.stdout.splitlines():
+            if "inet " in il and "127.0.0.1" not in il:
+                ip_info = il.split("inet ")[1].split()[0]
+                break
+
+        interfaces.append((iface, state, ip_info))
+
+    return interfaces
+
+
+def select_interface() -> str:
+    print_info("Scanning for available network interfaces...")
+    print()
+    interfaces = get_available_interfaces()
+
+    if not interfaces:
+        print_error("No network interfaces found.")
+        sys.exit(1)
+
+    print_info(f"Found {len(interfaces)} network interface(s):")
+    print()
+
+    for i, (iface, state, ip_info) in enumerate(interfaces, 1):
+        if state == "UP":
+            state_str = f"{Colors.GREEN}UP{Colors.NC}"
+        elif state == "DOWN":
+            state_str = f"{Colors.RED}DOWN{Colors.NC}"
+        else:
+            state_str = f"{Colors.YELLOW}{state}{Colors.NC}"
+        print(f"  {i}) {iface} ({state_str}) - {ip_info}")
+
+    print()
+    while True:
+        try:
+            choice = int(input(f"Select network interface (1-{len(interfaces)}): "))
+            if 1 <= choice <= len(interfaces):
+                iface = interfaces[choice - 1][0]
+                print_info(f"Selected interface: {iface}")
+                return iface
+            print_error(f"Enter a number between 1 and {len(interfaces)}.")
+        except ValueError:
+            print_error("Invalid input. Enter a number.")
+
+
+# ---------------------------------------------------------------------------
+# Backup
+# ---------------------------------------------------------------------------
+
+def backup_config(config: dict[str, str], interface: str) -> str:
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    backup_file = f"/tmp/network_backup_{timestamp}.txt"
+    print_info(f"Backing up current interface config to {backup_file}")
+
+    with open(backup_file, "w", encoding="utf-8") as f:
+        f.write(f"# Network configuration backup - {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"# Robot type : {config['robot_type']}\n")
+        f.write(f"# Interface  : {interface}\n")
+        f.write(f"# Host IP    : {config['ip_address']}\n")
+        f.write(f"# Subnet mask: {config['subnet_mask']}\n\n")
+
+        f.write("# Current IP addresses:\n")
+        r = run_command(["sudo", "ip", "addr", "show", interface], check=False)
+        for line in r.stdout.splitlines():
+            if "inet" in line:
+                f.write(line + "\n")
+
+        f.write("\n# Current routes for this interface:\n")
+        r = run_command(["sudo", "ip", "route", "show"], check=False)
+        for line in r.stdout.splitlines():
+            if interface in line:
+                f.write(line + "\n")
+
+    print_info(f"Backup saved: {backup_file}")
+    return backup_file
+
+
+# ---------------------------------------------------------------------------
+# Firewall — scoped rule, not global disable
+# ---------------------------------------------------------------------------
+
+def configure_firewall(interface: str) -> None:
+    if not shutil.which("ufw"):
+        print_warning("ufw not found — skipping firewall configuration.")
+        return
+
+    status_result = run_command(["sudo", "ufw", "status"], check=False)
+    if "inactive" in status_result.stdout.lower():
+        print_info("ufw is inactive — no firewall rules needed.")
+        return
+
+    print_info(f"Adding scoped ufw rules for interface {interface} (robot subnet only)...")
+    in_result = run_command(["sudo", "ufw", "allow", "in", "on", interface], check=False)
+    out_result = run_command(["sudo", "ufw", "allow", "out", "on", interface], check=False)
+
+    if in_result.returncode == 0 and out_result.returncode == 0:
+        print_info(f"ufw: allowed all traffic in/out on {interface}.")
+    else:
+        print_warning("Could not add ufw rules — robot communication may be blocked.")
+        print_warning("Run manually: sudo ufw allow in on <interface> && sudo ufw allow out on <interface>")
+
+
+# ---------------------------------------------------------------------------
+# Interface configuration
+# ---------------------------------------------------------------------------
+
+def configure_interface(config: dict[str, str], interface: str) -> None:
+    print_info(f"Configuring {interface} for {config['connection_name']}...")
+
+    configure_firewall(interface)
+
+    # Flush existing addresses and bring the interface up.
+    run_command(["sudo", "ip", "addr", "flush", "dev", interface], check=False)
+    run_command(["sudo", "ip", "link", "set", interface, "up"])
+    time.sleep(1)
+
+    # Assign static IP.
+    cidr = sum(bin(int(x)).count("1") for x in config["subnet_mask"].split("."))
+    run_command(["sudo", "ip", "addr", "add", f"{config['ip_address']}/{cidr}", "dev", interface])
+
+    # Add default route only when a gateway is specified.
+    if config["gateway"]:
+        run_command(
+            ["sudo", "ip", "route", "add", "default", "via", config["gateway"], "dev", interface],
+            check=False,
+        )
+
+    # Verify.
+    result = run_command(["sudo", "ip", "addr", "show", interface], check=False)
+    if config["ip_address"] in result.stdout:
+        print_info("Interface configured successfully.")
+        print_info(f"  Interface : {interface}")
+        print_info(f"  Host IP   : {config['ip_address']}/{cidr}")
+        if config["gateway"]:
+            print_info(f"  Gateway   : {config['gateway']}")
+    else:
+        print_error("Failed to assign IP address to interface.")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Connectivity checks
+# ---------------------------------------------------------------------------
+
+def check_interface_state(interface: str) -> None:
+    result = run_command(["sudo", "ip", "link", "show", interface], check=False)
+    if "state UP" in result.stdout:
+        print_info(f"Interface {interface} is UP.")
+    else:
+        print_warning(f"Interface {interface} is not UP — check the ethernet cable.")
+
+
+def ping_robot(robot_ip: str) -> bool:
+    print_info(f"Pinging robot at {robot_ip}...")
+    result = run_command(["ping", "-c", "1", "-W", "3", robot_ip], check=False)
+    if result.returncode == 0:
+        print_info(f"Robot at {robot_ip} is reachable.")
+        return True
+    print_warning(f"Robot at {robot_ip} is not reachable.")
+    print_warning("This is expected if the robot is powered off or not yet connected.")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Configure a network interface for Unitree G1 robot communication."
+    )
+    parser.add_argument("-i", "--interface", help="Network interface to configure (e.g. enp5s0)")
+    args = parser.parse_args()
+
+    print_info("Starting network setup for robot communication.")
+
+    check_linux()
+    check_sudo()
+
+    config = select_robot_type()
+
+    if args.interface:
+        result = run_command(["sudo", "ip", "link", "show", args.interface], check=False)
+        if result.returncode != 0:
+            print_error(f"Interface '{args.interface}' does not exist.")
+            sys.exit(1)
+        interface = args.interface
+        print_info(f"Using specified interface: {interface}")
+    else:
+        interface = select_interface()
+
+    backup_config(config, interface)
+    configure_interface(config, interface)
+    check_interface_state(interface)
+    ping_robot(config["robot_ip_address"])
+
+    print_info("Network setup complete.")
+    print_info(f"Interface {interface} is ready for {config['connection_name']} communication.")
+    print_warning("Note: this configuration is not persistent and will reset on reboot.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/gear_sonic_deploy/scripts/setup_network.py
+++ b/gear_sonic_deploy/scripts/setup_network.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """
-Setup a network interface for communication with the Unitree G1 robot.
+Assign a static IP to the wired ethernet port connected to the Unitree G1 robot.
 
-Assigns a static IP to the selected ethernet interface so the host machine
-can communicate with the robot over the 192.168.123.x subnet.
+The G1 communicates exclusively over a dedicated wired ethernet link on the
+192.168.123.0/24 subnet (robot at .164, host at .222). This connection carries
+both DDS motor control traffic (500 Hz, latency-critical) and the camera stream.
+WiFi cannot substitute for this link.
+
+This script assigns the static IP via NetworkManager so the assignment is
+NM-aware and persists for the session without being reverted by the NM daemon.
 
 Requirements: Ubuntu 20.04 / 22.04 / 24.04, NetworkManager (nmcli), sudo privileges.
 ufw is optional — if present, a scoped allow rule is added for the robot
-subnet rather than the entire interface.
+subnet (192.168.123.0/24) rather than the entire interface.
 
 Usage:
     python3 setup_network.py                  # interactive robot + interface selection


### PR DESCRIPTION
## Summary

Adds `gear_sonic_deploy/scripts/setup_network.py`, a guided Python script that correctly configures the host workstation's wired ethernet port for communication with the Unitree G1 robot, and updates all real-robot workflow docs to reference it as an explicit prerequisite.

### Problem

The G1 robot communicates over a dedicated wired ethernet link on `192.168.123.0/24` (robot at `.164`, host at `.222`). This link carries both DDS motor control traffic (500 Hz, latency-critical) and the camera stream — WiFi cannot substitute. Previously, docs gave only a vague instruction to "set a static IP per the Unitree SDK guide," leaving users to guess why `deploy.sh` or `--camera-host 192.168.123.164` failed on first run.

### Changes

**New script: `gear_sonic_deploy/scripts/setup_network.py`**
- Assigns the static IP via `nmcli` (NetworkManager-aware) so it is not silently reverted by the NM daemon on Ubuntu
- Validates Ubuntu version (20.04 / 22.04 / 24.04) and checks `nmcli` presence with a clear install hint
- Scopes `ufw` rules to the robot subnet (`192.168.123.0/24`) rather than the entire interface
- Skips `wlan*` interfaces in NIC enumeration (wired-only context)
- Supports both interactive mode (guided robot + interface selection) and `--interface` flag for scripted use
- Connection profile persists across reboots until explicitly removed

**Docs updated to reference `setup_network.py` as a prerequisite:**
- `docs/source/references/decoupled_wbc.md` — bold wired-ethernet-only requirement, clarify WiFi stays up on a separate interface
- `docs/source/tutorials/vr_wholebody_teleop.md`
- `docs/source/user_guide/teleoperation.md`
- `docs/source/tutorials/data_collection.md`
- `docs/source/tutorials/vla_inference.md`