### PR TITLE
fix(inference): align gear_sonic[inference] with Isaac-GR00T package name and Python 3.12

### DIFF
--- a/gear_sonic/pyproject.toml
+++ b/gear_sonic/pyproject.toml
@@ -80,6 +80,9 @@ camera = [
 ]
 # Inference: VLA inference client for running Isaac-GR00T policies
 # Usage: pip install -e "gear_sonic[inference]"
+# NVIDIA/Isaac-GR00T declares [project] name = "gr00t". The PEP 508 name
+# must match that metadata or uv/pip fail with:
+#   Package metadata name `gr00t` does not match given name `Isaac-GR00T`
 inference = [
     "pyzmq",
     "msgpack",
@@ -88,7 +91,7 @@ inference = [
     "tyro",
     "opencv-python",
     "scipy",
-    "Isaac-GR00T @ git+https://github.com/NVIDIA/Isaac-GR00T.git",
+    "gr00t @ git+https://github.com/NVIDIA/Isaac-GR00T.git",
 ]
 # Training: full RL training stack (Isaac Lab must be installed separately)
 # Usage: pip install -e "gear_sonic[training]"

--- a/install_scripts/install_inference.sh
+++ b/install_scripts/install_inference.sh
@@ -6,6 +6,9 @@
 # Installs gear_sonic[inference] which pulls in the Isaac-GR00T library,
 # PyZMQ, msgpack, Pinocchio, and other inference dependencies.
 #
+# Isaac-GR00T currently requires Python >=3.12,<3.13, so this venv is 3.12.
+# Other install_* scripts stay on 3.10 because they do not install GR00T.
+#
 # Usage:  bash install_scripts/install_inference.sh   (run from repo root)
 
 set -euo pipefail
@@ -13,11 +16,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ── 0. System dependencies ────────────────────────────────────────────────────
+# ── 0. System dependencies ────────────────────────────────────────────
 ARCH="$(uname -m)"
 echo "[OK] Architecture: $ARCH"
 
-# ── 1. Ensure uv is installed and available ──────────────────────────────────
+# ── 1. Ensure uv is installed and available ─────────────────────────────
 if ! command -v uv &>/dev/null; then
     echo "[INFO] uv not found – installing via official installer …"
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -40,19 +43,19 @@ if ! command -v uv &>/dev/null; then
 fi
 echo "[OK] uv $(uv --version)"
 
-# ── 2. Install a uv-managed Python 3.10 (includes dev headers / Python.h) ────
-echo "[INFO] Installing uv-managed Python 3.10 (includes development headers) …"
-uv python install 3.10
-MANAGED_PY="$(uv python find --no-project 3.10)"
+# ── 2. Install a uv-managed Python 3.12 (Isaac-GR00T requires >=3.12,<3.13) ──
+echo "[INFO] Installing uv-managed Python 3.12 (Isaac-GR00T requires >=3.12,<3.13) …"
+uv python install 3.12
+MANAGED_PY="$(uv python find --no-project 3.12)"
 echo "[OK] Using Python: $MANAGED_PY"
 
-# ── 3. Clean previous venv (if any) ──────────────────────────────────────────
+# ── 3. Clean previous venv (if any) ─────────────────────────────────────
 cd "$REPO_ROOT"
 echo "[INFO] Removing old .venv_inference (if present) …"
 rm -rf .venv_inference
 
-# ── 4. Create venv & install inference extra ─────────────────────────────────
-echo "[INFO] Creating .venv_inference with uv-managed Python 3.10 …"
+# ── 4. Create venv & install inference extra ────────────────────────────
+echo "[INFO] Creating .venv_inference with uv-managed Python 3.12 …"
 uv venv .venv_inference --python "$MANAGED_PY" --prompt gear_sonic_inference
 # shellcheck disable=SC1091
 source .venv_inference/bin/activate


### PR DESCRIPTION
## Problem

`bash install_scripts/install_inference.sh` fails while installing `gear_sonic[inference]`:

```
Package metadata name `gr00t` does not match given name `Isaac-GR00T`
```

That is the failure reported on [NVIDIA/Isaac-GR00T#748](https://github.com/NVIDIA/Isaac-GR00T/issues/748). The bug is in this repo, not in Isaac-GR00T.

Current extra:

```toml
"Isaac-GR00T @ git+https://github.com/NVIDIA/Isaac-GR00T.git"
```

Current Isaac-GR00T `pyproject.toml`:

```toml
name = "gr00t"
requires-python = ">=3.12,<3.13"
```

Even after the name fix, `install_inference.sh` still creates a Python 3.10 venv, which Isaac-GR00T will reject.

## Change

1. `gear_sonic/pyproject.toml` — depend on `gr00t @ git+https://github.com/NVIDIA/Isaac-GR00T.git` (PEP 508 name matches package metadata).
2. `install_scripts/install_inference.sh` — install uv-managed Python 3.12 for `.venv_inference` only.

Other `install_*` scripts stay on 3.10. They do not pull Isaac-GR00T.

## Why this is scoped this way

- Teleop / camera / MuJoCo / ROS scripts are intentionally 3.10 and should not be moved in this PR.
- `gear_sonic` still declares `requires-python = ">=3.10"`; 3.12 is compatible.
- No runtime policy or controller changes.

## Validation

- Diff is two files.
- Did not run a full `install_inference.sh` here (downloads Isaac-GR00T + CUDA stack). Happy to iterate if CI or a maintainer wants a different pin (commit SHA vs `git+...git`).

Fixes the install path described in NVIDIA/Isaac-GR00T#748.

Signed-off-by: John Wantz Jr.
